### PR TITLE
fix(annotator): fine tune padding and size for annotator button images

### DIFF
--- a/src/components/file-annotator/FileAnnotator.styles.ts
+++ b/src/components/file-annotator/FileAnnotator.styles.ts
@@ -54,7 +54,6 @@ export const ButtonContainer = styled("div", {
 export const Button = styled("button", {
   background: "transparent",
   border: "none",
-  padding: "4px",
   cursor: "pointer",
   display: "flex",
   alignItems: "center",
@@ -65,20 +64,28 @@ export const Button = styled("button", {
     background: "rgba(0, 0, 0, 0.1)",
   },
 
-  img: {
-    width: "20px",
-    height: "20px",
-  },
-
   variants: {
-    variant: {
-      search: {},
-      searchSingle: {},
-      replaceAll: {},
-      replace: {},
-      tagAll: {},
-      tag: {},
+    smallImage: {
+      true: {
+        padding: "2px",
+
+        img: {
+          width: "24px",
+          height: "24px",
+        },
+      },
+      false: {
+        padding: "4px",
+
+        img: {
+          width: "20px",
+          height: "20px",
+        },
+      },
     },
+  },
+  defaultVariants: {
+    smallImage: false,
   },
 });
 

--- a/src/components/file-annotator/Mark.tsx
+++ b/src/components/file-annotator/Mark.tsx
@@ -199,7 +199,6 @@ export const Mark: FC<MarkProps> = ({ children, annotation, ...props }) => {
               <S.ButtonContainer>
                 <S.Button
                   type="button"
-                  css={{ variant: "replace" }}
                   onClick={() => {
                     setDialogState({
                       open: true,
@@ -215,7 +214,7 @@ export const Mark: FC<MarkProps> = ({ children, annotation, ...props }) => {
                 </S.Button>
                 <S.Button
                   type="button"
-                  css={{ variant: "replaceAll" }}
+                  smallImage
                   onClick={() => {
                     setDialogState({
                       open: true,
@@ -227,11 +226,14 @@ export const Mark: FC<MarkProps> = ({ children, annotation, ...props }) => {
                   }}
                   title="Reemplazar todas las ocurrencias"
                 >
-                  <img src="button-icons/replace-all.svg" alt="Replace All" />
+                  <img
+                    style={{ width: "24px", height: "24px" }}
+                    src="button-icons/replace-all.svg"
+                    alt="Replace All"
+                  />
                 </S.Button>
                 <S.Button
                   type="button"
-                  css={{ variant: "tag" }}
                   onClick={() => handleAnnotationOperation("remove")}
                   title="Eliminar esta ocurrencia"
                 >
@@ -239,11 +241,17 @@ export const Mark: FC<MarkProps> = ({ children, annotation, ...props }) => {
                 </S.Button>
                 <S.Button
                   type="button"
-                  css={{ variant: "tagAll" }}
+                  smallImage
+                  css={{ pt: 1, pb: 0 }}
                   onClick={() => handleAnnotationOperation("removeByText")}
                   title="Eliminar todas las ocurrencias"
                 >
-                  <img src="button-icons/delete-all.svg" alt="Delete All" />
+                  <img
+                    src="button-icons/delete-all.svg"
+                    alt="Delete All"
+                    width="24.5px"
+                    height="24.5px"
+                  />
                 </S.Button>
               </S.ButtonContainer>
             ) : null}


### PR DESCRIPTION
## Summary by Sourcery

Refine padding and image sizing for file annotator buttons by introducing a smallImage variant and updating button usages accordingly

Enhancements:
- Introduce smallImage variant in Button component to control padding and icon dimensions
- Update Mark component to remove old variant props, apply smallImage flag, and set inline image sizes for replace-all and delete-all buttons