### PR TITLE
fix(annotator): adjust sarchbar and file viewer paddings to avoid too…

### DIFF
--- a/src/components/file-annotator/FileAnnotator.styles.ts
+++ b/src/components/file-annotator/FileAnnotator.styles.ts
@@ -10,6 +10,7 @@ export const Container = styled("div", {
 export const File = styled("div", {
   px: "$xl",
   pb: "$xl",
+  pt: "$l",
 
   "& p, & span, & em": {
     fontFamily: "$file",
@@ -133,6 +134,7 @@ export const Mark = styled("mark", {
 
 export const SearchContainer = styled("div", {
   p: "$l",
+  pb: 0,
 
   zIndex: 1,
   top: 0,

--- a/src/components/file-annotator/Mark.tsx
+++ b/src/components/file-annotator/Mark.tsx
@@ -20,7 +20,7 @@ interface MarkProps extends HTMLAttributes<HTMLSpanElement> {
 type DialogState = {
   open: boolean;
   title?: string;
-  action: "replace" | "replaceAll" | "remove" | "removeAll";
+  action: "replace" | "replaceAll" | "removeAll";
   suffix: number | null;
   selectedOption: SelectOption | undefined;
 };
@@ -86,16 +86,35 @@ export const Mark: FC<MarkProps> = ({ children, annotation, ...props }) => {
     const annotationData = createAnnotationData(annotation as LabelAnnotation);
     if (!annotationData) return;
 
-    if (operation === "remove" || operation === "removeByText") {
+    if (operation === "removeByText") {
       setDialogState({
         open: true,
-        action: operation === "remove" ? "remove" : "removeAll",
+        action: "removeAll",
         suffix: null,
         selectedOption: undefined,
       });
     } else {
       annotationOperations[operation](annotationData);
     }
+  };
+
+  const handleRemoveAll = () => {
+    const annotationData = createAnnotationData(annotation as LabelAnnotation);
+    if (!annotationData) return;
+
+    setDialogState({
+      open: true,
+      action: "removeAll",
+      suffix: null,
+      selectedOption: undefined,
+    });
+  };
+
+  const handleRemove = () => {
+    const annotationData = createAnnotationData(annotation as LabelAnnotation);
+    if (!annotationData) return;
+
+    remove(annotationData);
   };
 
   const handleAddBySearch = (annotation: LabelAnnotation) => {
@@ -113,20 +132,13 @@ export const Mark: FC<MarkProps> = ({ children, annotation, ...props }) => {
 
   const applyChanges = () => {
     if (!dialogState.selectedOption) {
-      if (
-        dialogState.action === "remove" ||
-        dialogState.action === "removeAll"
-      ) {
+      if (dialogState.action === "removeAll") {
         const annotationData = createAnnotationData(
           annotation as LabelAnnotation,
         );
         if (!annotationData) return;
 
-        if (dialogState.action === "remove") {
-          remove(annotationData);
-        } else {
-          removeByText(annotationData);
-        }
+        removeByText(annotationData);
       }
     } else {
       const annotationData = createAnnotationData(
@@ -234,7 +246,7 @@ export const Mark: FC<MarkProps> = ({ children, annotation, ...props }) => {
                 </S.Button>
                 <S.Button
                   type="button"
-                  onClick={() => handleAnnotationOperation("remove")}
+                  onClick={() => handleRemove()}
                   title="Eliminar esta ocurrencia"
                 >
                   <img src="button-icons/delete-one.svg" alt="Delete One" />
@@ -243,7 +255,7 @@ export const Mark: FC<MarkProps> = ({ children, annotation, ...props }) => {
                   type="button"
                   smallImage
                   css={{ pt: 1, pb: 0 }}
-                  onClick={() => handleAnnotationOperation("removeByText")}
+                  onClick={() => handleRemoveAll()}
                   title="Eliminar todas las ocurrencias"
                 >
                   <img
@@ -268,15 +280,10 @@ export const Mark: FC<MarkProps> = ({ children, annotation, ...props }) => {
               }))
             }
           >
-            {dialogState.action === "remove" ||
-            dialogState.action === "removeAll" ? (
+            {dialogState.action === "removeAll" ? (
               <>
                 <DialogMessage>
-                  ¿Deseas{" "}
-                  {dialogState.action === "remove"
-                    ? "eliminar la etiqueta"
-                    : "eliminar todas las etiquetas"}{" "}
-                  <b>{children}</b>?
+                  ¿Deseas eliminar todas las etiquetas <b>{children}</b>?
                 </DialogMessage>
                 <DialogButtons>
                   <Button onClick={applyChanges}>Sí, eliminar</Button>


### PR DESCRIPTION
…ltip cutoff

## Summary by Sourcery

Adjust paddings in the file annotator to prevent tooltip cutoff.

Bug Fixes:
- Add top padding to the file viewer container to avoid content cutoff.
- Remove bottom padding from the search bar container to prevent tooltip cutoff.