### PR TITLE
Sync develop

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
-appId: com.electron.app
-productName: vite-electron-test
+appId: aymurai.app
+productName: AymurAI
 directories:
   buildResources: build
 files:
@@ -12,7 +12,8 @@ files:
 asarUnpack:
   - resources/**
 win:
-  executableName: vite-electron-test
+  executableName: AymurAI
+  icon: src/renderer/public/brand/logo256-text.png
 nsis:
   artifactName: ${name}-${version}-setup.${ext}
   shortcutName: ${productName}
@@ -20,6 +21,7 @@ nsis:
   createDesktopShortcut: always
 mac:
   entitlementsInherit: build/entitlements.mac.plist
+  icon: src/renderer/public/brand/logo256-text.png
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
@@ -33,7 +35,7 @@ linux:
     - AppImage
     - snap
     - deb
-  maintainer: electronjs.org
+  maintainer: datagenero.org
   category: Utility
 appImage:
   artifactName: ${name}-${version}.${ext}


### PR DESCRIPTION
## Summary by Sourcery

Revamp electron-builder configuration to apply AymurAI branding and update platform-specific settings

Build:
- Set appId to aymurai.app and productName to AymurAI
- Update Windows executableName to AymurAI and add custom icon
- Include custom icon for macOS builds
- Change Linux maintainer to datagenero.org