### PR TITLE
fix(schema): make predict alt values nullable

### DIFF
--- a/src/renderer/src/schema/predict.ts
+++ b/src/renderer/src/schema/predict.ts
@@ -8,9 +8,9 @@ export const predictSchema = z.object({
       start_char: z.number(),
       end_char: z.number(),
       attrs: z.object({
-        aymurai_alt_start_char: z.number(),
-        aymurai_alt_end_char: z.number(),
-        aymurai_alt_text: z.string(),
+        aymurai_alt_start_char: z.number().nullable(),
+        aymurai_alt_end_char: z.number().nullable(),
+        aymurai_alt_text: z.string().nullable(),
         aymurai_label: z.string(),
         aymurai_label_subclass: z.array(z.string()).nullable(),
       }),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Permit null values for alternative prediction character offsets and text in the prediction schema to avoid schema validation failures when these fields are absent.