### PR TITLE
 Refactor navigation menu to header popover

### DIFF
--- a/src/renderer/src/components/features-menu.tsx
+++ b/src/renderer/src/components/features-menu.tsx
@@ -1,22 +1,34 @@
 import { FEATURES } from "@/constants";
+import { css } from "@/styled/css";
 import { Grid, Stack, styled } from "@/styled/jsx";
 import type { FeatureFlowEnum } from "@/types/features";
 import { Link } from "@tanstack/react-router";
-import { House } from "phosphor-react";
+import { DotsNine } from "phosphor-react";
 import FeatureIcon from "./feature-icon";
 import Button from "./ui/button";
 import Card from "./ui/card";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+
+const tooltipStyle = css({
+  padding: "2",
+  textStyle: "label.md.default",
+});
 
 export default function FeaturesMenu() {
   const features = Object.entries(FEATURES);
   return (
     <Popover>
-      <PopoverTrigger asChild>
-        <Button size="icon-sm" style={{ padding: 2 }} aria-label="Ir al inicio">
-          <House size={32} />
-        </Button>
-      </PopoverTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button size="icon-sm" style={{ padding: 2 }} aria-label="Menú">
+              <DotsNine size={32} />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent className={tooltipStyle}>Menú</TooltipContent>
+      </Tooltip>
       <PopoverContent align="end">
         <Grid columns={2} padding="4">
           {features.map(([value, feature]) => (

--- a/src/renderer/src/components/home/stepper.tsx
+++ b/src/renderer/src/components/home/stepper.tsx
@@ -1,5 +1,6 @@
 import { css, sva } from "@/styled/css";
 import { stack } from "@/styled/patterns";
+import { FeatureFlowEnum } from "@/types/features";
 
 const stepper = css({
   ...stack.raw({ align: "center", direction: "row" }),
@@ -49,6 +50,22 @@ const step = sva({
   },
 });
 
+// Step labels per feature flow
+const STEP_LABELS: Record<FeatureFlowEnum, [string, string, string, string]> = {
+  [FeatureFlowEnum.Dataset]: [
+    "Selección",
+    "Extracción",
+    "Validación",
+    "Finalización",
+  ],
+  [FeatureFlowEnum.Anonymizer]: [
+    "Previsualización",
+    "Procesamiento",
+    "Validación",
+    "Finalización",
+  ],
+};
+
 type StepStatus = "complete" | "pending" | "in_progress";
 interface StepProps {
   children: string;
@@ -79,8 +96,11 @@ function Step({ children, status, number }: StepProps) {
 
 interface StepperProps {
   currentStep: number;
+  feature: FeatureFlowEnum;
 }
-export default function Stepper({ currentStep }: StepperProps) {
+export default function Stepper({ currentStep, feature }: StepperProps) {
+  const labels = STEP_LABELS[feature];
+
   const status = (step: number): StepStatus => {
     if (step === currentStep) return "in_progress";
     if (step > currentStep) return "pending";
@@ -89,18 +109,14 @@ export default function Stepper({ currentStep }: StepperProps) {
 
   return (
     <div className={stepper}>
-      <Step number={1} status={status(1)}>
-        Selección
-      </Step>
-      <Step number={2} status={status(2)}>
-        Extracción
-      </Step>
-      <Step number={3} status={status(3)}>
-        Validación
-      </Step>
-      <Step number={4} status={status(4)}>
-        Finalización
-      </Step>
+      {labels.map((label, i) => {
+        const stepNumber = i + 1;
+        return (
+          <Step key={label} number={stepNumber} status={status(stepNumber)}>
+            {label}
+          </Step>
+        );
+      })}
     </div>
   );
 }

--- a/src/renderer/src/components/home/stepper.tsx
+++ b/src/renderer/src/components/home/stepper.tsx
@@ -64,6 +64,24 @@ const STEP_LABELS: Record<FeatureFlowEnum, [string, string, string, string]> = {
     "Validación",
     "Finalización",
   ],
+  [FeatureFlowEnum.VoiceToText]: [
+    "Selección",
+    "Procesamiento",
+    "Validación",
+    "Finalización",
+  ],
+  [FeatureFlowEnum.Summary]: [
+    "Selección",
+    "Procesamiento",
+    "Validación",
+    "Finalización",
+  ],
+  [FeatureFlowEnum.PdfToWord]: [
+    "Selección",
+    "Procesamiento",
+    "Validación",
+    "Finalización",
+  ],
 };
 
 type StepStatus = "complete" | "pending" | "in_progress";

--- a/src/renderer/src/components/how-it-works-modal.tsx
+++ b/src/renderer/src/components/how-it-works-modal.tsx
@@ -2,7 +2,7 @@ import { SectionTitle } from "@/layout/section-title";
 import { css } from "@/styled/css";
 import { HStack, Stack } from "@/styled/jsx";
 import type { FeatureFlowEnum } from "@/types/features";
-import { Info, X } from "phosphor-react";
+import { Question, X } from "phosphor-react";
 import HowItWorks from "./how-it-works";
 import { Dialog, DialogClose, DialogContent, DialogTrigger } from "./ui/dialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
@@ -50,7 +50,7 @@ export default function HowItWorksModal({ feature }: HowItWorksModalProps) {
               className={modalButton}
               aria-label="Información sobre AymurAI"
             >
-              <Info size={32} />
+              <Question size={32} />
             </button>
           </DialogTrigger>
         </TooltipTrigger>

--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -1,4 +1,11 @@
-import { Database, Detective, type Icon } from "phosphor-react";
+import {
+  Database,
+  Detective,
+  FileArrowDown,
+  FileAudio,
+  FileText,
+  type Icon,
+} from "phosphor-react";
 import { FeatureFlowEnum, featureName } from "./types/features";
 
 export const DATAGENERO_URL = "https://www.datagenero.org/";
@@ -16,6 +23,21 @@ export const FEATURES: Record<FeatureFlowEnum, Feature> = {
     subtitle:
       "Anonimiza resoluciones judiciales de manera automática y editable",
     icon: Detective,
+  },
+  [FeatureFlowEnum.VoiceToText]: {
+    title: featureName(FeatureFlowEnum.VoiceToText),
+    subtitle: "Convierte archivos de audio en texto",
+    icon: FileAudio,
+  },
+  [FeatureFlowEnum.Summary]: {
+    title: featureName(FeatureFlowEnum.Summary),
+    subtitle: "Resume textos largos o resoluciones",
+    icon: FileText,
+  },
+  [FeatureFlowEnum.PdfToWord]: {
+    title: featureName(FeatureFlowEnum.PdfToWord),
+    subtitle: "Convierte documentos PDF a formato Word",
+    icon: FileArrowDown,
   },
 };
 

--- a/src/renderer/src/routes/app.$feature/route.tsx
+++ b/src/renderer/src/routes/app.$feature/route.tsx
@@ -17,7 +17,7 @@ import { FeatureFlowEnum, featureName } from "@/types/features";
 
 // Validation schema for feature parameter
 const featureParamSchema = z.object({
-  feature: z.enum([FeatureFlowEnum.Dataset, FeatureFlowEnum.Anonymizer]),
+  feature: z.nativeEnum(FeatureFlowEnum),
 });
 
 export const Route = createFileRoute("/app/$feature")({

--- a/src/renderer/src/routes/app.$feature/route.tsx
+++ b/src/renderer/src/routes/app.$feature/route.tsx
@@ -50,11 +50,7 @@ function AppLayoutRoute() {
     <Stack width="screen" height="screen" gap="0">
       <Header
         title={featureName(feature)}
-        center={
-          feature === FeatureFlowEnum.Dataset ? (
-            <Stepper currentStep={currentStep} />
-          ) : undefined
-        }
+        center={<Stepper currentStep={currentStep} feature={feature} />}
         right={
           <HStack>
             {tutorialSeen && <HowItWorksModal feature={feature} />}

--- a/src/renderer/src/store/useLocal.ts
+++ b/src/renderer/src/store/useLocal.ts
@@ -23,6 +23,9 @@ const useLocalStore = create<LocalStorageStore>()(
         tutorialsSeen: {
           [FeatureFlowEnum.Anonymizer]: false,
           [FeatureFlowEnum.Dataset]: false,
+          [FeatureFlowEnum.VoiceToText]: false,
+          [FeatureFlowEnum.Summary]: false,
+          [FeatureFlowEnum.PdfToWord]: false,
         },
         hasSeenTutorial: (feature: FeatureFlowEnum) =>
           get().tutorialsSeen[feature],

--- a/src/renderer/src/types/features.ts
+++ b/src/renderer/src/types/features.ts
@@ -1,12 +1,18 @@
 export enum FeatureFlowEnum {
   Dataset = "DATA_SET",
   Anonymizer = "ANONYMIZER",
+  VoiceToText = "VOICE_TO_TEXT",
+  Summary = "SUMMARY",
+  PdfToWord = "PDF_TO_WORD",
 }
 
 export const featureName = (feature: FeatureFlowEnum): string => {
   const names: Record<FeatureFlowEnum, string> = {
     [FeatureFlowEnum.Dataset]: "Set de datos",
     [FeatureFlowEnum.Anonymizer]: "Anonimizador",
+    [FeatureFlowEnum.VoiceToText]: "Voz a Texto",
+    [FeatureFlowEnum.Summary]: "Resumen",
+    [FeatureFlowEnum.PdfToWord]: "PDF a Word",
   };
 
   return names[feature];


### PR DESCRIPTION
Refactors the navigation flow to move features into a common header popover, updates icons to match design, and adds tooltips to the menu items. All typescript and lint checks passing.

<img width="503" height="491" alt="image" src="https://github.com/user-attachments/assets/19833084-2b4b-4b9b-81ca-5559d703477e" />

## Summary by Sourcery

Migrate the app’s navigation and UI to a new TanStack Router–based layout with a header popover menu and shared feature flows, while introducing a new design system and updating build configuration and dependencies.

New Features:
- Introduce TanStack React Router routing with a generated route tree and feature-scoped app flows under /app/$feature.
- Add a new home experience with host selection, feature picker, and per-feature stepper plus onboarding/how-it-works flows.
- Provide new shared layout components (header, main content, footer, loading) and Radix-based UI primitives (buttons, inputs, dialogs, popovers, tooltips, cards, drop areas, back buttons).
- Add persisted per-feature tutorial state so onboarding/how-it-works is only shown once per tool.
- Expose new finish and validation components for dataset and anonymizer flows, and a new anonymization query that returns downloadable documents.

Bug Fixes:
- Handle prediction API responses and errors more robustly, including reading data from Axios responses and relaxing prediction schema fields to allow nulls.
- Fix the anonymizer label enum value and visible text for the Niño/a adolescente option.
- Prevent stale file parsing results by including file size in the file parser query key.
- Improve remote host connection error handling and URL parsing, returning clearer user-facing error messages.

Enhancements:
- Refactor preview, process, validation, onboarding, and finish flows into route components that use feature parameters instead of a custom router, and consolidate navigation logic.
- Restructure shared components exports, adding new onboarding cards and grids while deprecating several Stitches-based primitives in favor of Panda CSS and new UI components.
- Switch several flows to use the new layout primitives and headers while keeping legacy main layout styles under a deprecated main-old module.
- Update aymurai service utilities to use standard React Query hooks with explicit zod parsing and add a query-based anonymize API wrapper.
- Enhance local store to also track per-feature tutorials and expose dedicated hooks for server host and tutorial state access.
- Improve stepper logic to compute steps from TanStack Router locations and support feature-based multi-step progress display in the header.
- Simplify Axios API utilities by removing the global response interceptor and handling response.data at call sites.

Build:
- Switch routing from React Router DOM to TanStack React Router, including Vite and electron-vite configuration updates for router codegen and environment handling.
- Introduce Panda CSS as the new styling system with tokens, text styles, animations, and PostCSS integration, while deprecating Stitches global styles.
- Update npm scripts for web/electron modes, add formatting and Panda codegen commands, and tweak typecheck and build scripts to use VITE_APP_MODE and cross-env.
- Refresh dependencies to newer React, React DOM, Electron, Axios, TanStack libraries, Radix UI primitives, and Panda CSS, and adjust pnpm settings.
- Revise README to describe the new router, tooling (pnpm, biome), and updated dev/build/validation/deployment scripts.