### PR TITLE
 Restore delete-one and delete-all hover actions on annotations

### DIFF
--- a/src/renderer/src/components/file/annotation-popover/index.tsx
+++ b/src/renderer/src/components/file/annotation-popover/index.tsx
@@ -26,12 +26,16 @@ interface AnnotationPopoverProps {
   children: ReactNode;
   onClickOne: (label: AllLabels, suffix: number | null) => void;
   onClickAll: (label: AllLabels, suffix: number | null) => void;
+  onDeleteOne?: () => void;
+  onDeleteAll?: () => void;
 }
 
 export default function AnnotationPopover({
   children,
   onClickAll,
   onClickOne,
+  onDeleteOne,
+  onDeleteAll,
 }: AnnotationPopoverProps) {
   const [open, setOpen] = useState(false);
   const closeTimer = useRef<ReturnType<typeof setTimeout>>(null);
@@ -91,7 +95,7 @@ export default function AnnotationPopover({
         }}
         onBlur={handleBlur}
       >
-        <Tagger onClickOne={onClickOne} onClickAll={onClickAll} />
+        <Tagger onClickOne={onClickOne} onClickAll={onClickAll} onDeleteOne={onDeleteOne} onDeleteAll={onDeleteAll} />
       </PopoverContent>
     </Popover>
   );

--- a/src/renderer/src/components/file/annotation-popover/tagger.tsx
+++ b/src/renderer/src/components/file/annotation-popover/tagger.tsx
@@ -39,8 +39,10 @@ const tagger = sva({
 interface MarkTaggerProps {
   onClickOne: (label: AllLabels, suffix: number | null) => void;
   onClickAll: (label: AllLabels, suffix: number | null) => void;
+  onDeleteOne?: () => void;
+  onDeleteAll?: () => void;
 }
-export default function Tagger({ onClickAll, onClickOne }: MarkTaggerProps) {
+export default function Tagger({ onClickAll, onClickOne, onDeleteOne, onDeleteAll }: MarkTaggerProps) {
   const { label: initialLabel, suffix: initialSuffix } = useAnnotation();
 
   const [label, setLabel] = useState<AllLabels | null>(initialLabel);
@@ -111,6 +113,38 @@ export default function Tagger({ onClickAll, onClickOne }: MarkTaggerProps) {
           height={IMG_SIZE}
         />
       </TaggerButton>
+      {onDeleteOne && (
+        <>
+          <div className={classes.divider} />
+          <TaggerButton
+            tooltip="Eliminar esta ocurrencia"
+            onClick={onDeleteOne}
+          >
+            <img
+              src={`${import.meta.env.BASE_URL}button-icons/delete-one.svg`}
+              alt="Eliminar esta ocurrencia"
+              width={IMG_SIZE}
+              height={IMG_SIZE}
+            />
+          </TaggerButton>
+        </>
+      )}
+      {onDeleteAll && (
+        <>
+          <div className={classes.divider} />
+          <TaggerButton
+            tooltip="Eliminar todas las ocurrencias"
+            onClick={onDeleteAll}
+          >
+            <img
+              src={`${import.meta.env.BASE_URL}button-icons/delete-all.svg`}
+              alt="Eliminar todas las ocurrencias"
+              width={IMG_SIZE}
+              height={IMG_SIZE}
+            />
+          </TaggerButton>
+        </>
+      )}
     </div>
   );
 }

--- a/src/renderer/src/components/file/tag-annotation/index.tsx
+++ b/src/renderer/src/components/file/tag-annotation/index.tsx
@@ -28,14 +28,14 @@ export default function TagAnnotation({
       `Annotation of type "tag" expected but got: ${annotation.type}`,
     );
 
-  const { updateLabel, updateByText, updateByCanonicalId, remove, removeByText, isAnnotable } = useAnnotation();
+  const { updateLabel, updateByText, remove, removeByText, isAnnotable } = useAnnotation();
   const [removeAllOpen, setRemoveAllOpen] = useState(false);
   const [replaceAllLabelWithSuffix, setReplaceAllLabelWithSuffix] = useState<
     AllLabels | AllLabelsWithSufix | null
   >(null);
   const tag = annotation.tag;
 
-  const { start, end, paragraphId, canonical_entity_id } = annotation as LabelAnnotation;
+  const { start, end, paragraphId } = annotation as LabelAnnotation;
   const annotationData = annotation.tag
     ? {
         text: children,
@@ -79,13 +79,14 @@ export default function TagAnnotation({
       </AnnotationPopover>
       <ReplaceDialog
         isOpen={!!replaceAllLabelWithSuffix}
+        text={children}
         label={replaceAllLabelWithSuffix ?? ""}
         onClose={(open) => !open && setReplaceAllLabelWithSuffix(null)}
         onConfirm={confirmReplaceAll}
       />
       <RemoveDialog
         isOpen={removeAllOpen}
-        label={tag ?? ""}
+        text={children}
         onClose={(open) => !open && setRemoveAllOpen(false)}
         onConfirm={confirmRemoveAll}
       />
@@ -125,12 +126,7 @@ export default function TagAnnotation({
 
   function confirmReplaceAll() {
     if (!annotationData || !replaceAllLabelWithSuffix) return;
-
-    if (canonical_entity_id) {
-      updateByCanonicalId(canonical_entity_id, replaceAllLabelWithSuffix);
-    } else {
-      updateByText(annotationData, replaceAllLabelWithSuffix);
-    }
+    updateByText(annotationData, replaceAllLabelWithSuffix);
     setReplaceAllLabelWithSuffix(null);
     showToast(
       "Se reemplazó la etiqueta en todas las ocurrencias.",

--- a/src/renderer/src/components/file/tag-annotation/index.tsx
+++ b/src/renderer/src/components/file/tag-annotation/index.tsx
@@ -12,6 +12,7 @@ import { showToast } from "@/features/showToast";
 import type { AllLabels, AllLabelsWithSufix } from "@/types/aymurai";
 import AnnotationPopover from "../annotation-popover";
 import SuggestionLabel from "../suggestion-label";
+import RemoveDialog from "./remove-dialog";
 import ReplaceDialog from "./replace-dialog";
 
 interface TagAnnotationProps {
@@ -27,7 +28,8 @@ export default function TagAnnotation({
       `Annotation of type "tag" expected but got: ${annotation.type}`,
     );
 
-  const { updateLabel, updateByText, updateByCanonicalId, isAnnotable } = useAnnotation();
+  const { updateLabel, updateByText, updateByCanonicalId, remove, removeByText, isAnnotable } = useAnnotation();
+  const [removeAllOpen, setRemoveAllOpen] = useState(false);
   const [replaceAllLabelWithSuffix, setReplaceAllLabelWithSuffix] = useState<
     AllLabels | AllLabelsWithSufix | null
   >(null);
@@ -68,6 +70,8 @@ export default function TagAnnotation({
       <AnnotationPopover
         onClickOne={handleReplaceOne}
         onClickAll={handleReplaceAll}
+        onDeleteOne={handleDeleteOne}
+        onDeleteAll={handleDeleteAll}
       >
         <SuggestionLabel isClickable label={tag} {...metadata}>
           {children}
@@ -78,6 +82,12 @@ export default function TagAnnotation({
         label={replaceAllLabelWithSuffix ?? ""}
         onClose={(open) => !open && setReplaceAllLabelWithSuffix(null)}
         onConfirm={confirmReplaceAll}
+      />
+      <RemoveDialog
+        isOpen={removeAllOpen}
+        label={tag ?? ""}
+        onClose={(open) => !open && setRemoveAllOpen(false)}
+        onConfirm={confirmRemoveAll}
       />
     </>
   );
@@ -94,6 +104,23 @@ export default function TagAnnotation({
   function handleReplaceAll(label: AllLabels, suffix: number | null) {
     const labelWithSuffix = suffix ? (`${label}_${suffix}` as const) : label;
     setReplaceAllLabelWithSuffix(labelWithSuffix);
+  }
+
+  function handleDeleteOne() {
+    if (!annotationData) return;
+    remove(annotationData);
+    showToast("Se eliminó la anotación.", "success", Check);
+  }
+
+  function handleDeleteAll() {
+    setRemoveAllOpen(true);
+  }
+
+  function confirmRemoveAll() {
+    if (!annotationData) return;
+    removeByText(annotationData);
+    setRemoveAllOpen(false);
+    showToast("Se eliminaron todas las ocurrencias.", "success", Check);
   }
 
   function confirmReplaceAll() {

--- a/src/renderer/src/components/file/tag-annotation/remove-dialog.tsx
+++ b/src/renderer/src/components/file/tag-annotation/remove-dialog.tsx
@@ -8,7 +8,7 @@ import {
 
 interface RemoveDialogProps {
   isOpen: boolean;
-  label: string;
+  text: string;
   onClose: (open: boolean) => void;
   onConfirm: () => void;
 }
@@ -16,15 +16,15 @@ export default function RemoveDialog({
   isOpen,
   onClose,
   onConfirm,
-  label,
+  text,
 }: RemoveDialogProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent>
-        <DialogTitle>Eliminar todas las ocurrencias</DialogTitle>
-        <p>
-          Se eliminarán todas las ocurrencias del grupo con la etiqueta{" "}
-          <b>{label}</b>. ¿Deseas continuar?
+        <DialogTitle>Eliminar ocurrencias con este texto</DialogTitle>
+        <p id="remove-dialog-description">
+          Se eliminarán todas las ocurrencias que coincidan exactamente con el
+          texto <b>{text}</b>. ¿Deseas continuar?
         </p>
         <DialogFooter>
           <Button onClick={onConfirm}>Eliminar</Button>

--- a/src/renderer/src/components/file/tag-annotation/remove-dialog.tsx
+++ b/src/renderer/src/components/file/tag-annotation/remove-dialog.tsx
@@ -1,0 +1,36 @@
+import Button from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface RemoveDialogProps {
+  isOpen: boolean;
+  label: string;
+  onClose: (open: boolean) => void;
+  onConfirm: () => void;
+}
+export default function RemoveDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+  label,
+}: RemoveDialogProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogTitle>Eliminar todas las ocurrencias</DialogTitle>
+        <p>
+          Se eliminarán todas las ocurrencias del grupo con la etiqueta{" "}
+          <b>{label}</b>. ¿Deseas continuar?
+        </p>
+        <DialogFooter>
+          <Button onClick={onConfirm}>Eliminar</Button>
+          <Button onClick={() => onClose(false)}>Cancelar</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/renderer/src/components/file/tag-annotation/replace-dialog.tsx
+++ b/src/renderer/src/components/file/tag-annotation/replace-dialog.tsx
@@ -8,6 +8,7 @@ import {
 
 interface ReplaceDialogProps {
   isOpen: boolean;
+  text: string;
   label: string;
   onClose: (open: boolean) => void;
   onConfirm: () => void;
@@ -16,6 +17,7 @@ export default function ReplaceDialog({
   isOpen,
   onClose,
   onConfirm,
+  text,
   label,
 }: ReplaceDialogProps) {
   return (
@@ -23,8 +25,9 @@ export default function ReplaceDialog({
       <DialogContent>
         <DialogTitle>Reemplazar todas las ocurrencias</DialogTitle>
         <p>
-          ¿Deseas reemplazar todas las ocurrencias del grupo con la etiqueta{" "}
-          <b>{label}</b>?
+          Se reemplazará la etiqueta en todas las ocurrencias que coincidan
+          exactamente con el texto <b>{text}</b> por <b>{label}</b>.
+          ¿Deseas continuar?
         </p>
         <DialogFooter>
           <Button onClick={onConfirm}>Aplicar</Button>


### PR DESCRIPTION
## Summary
- Crea `RemoveDialog` para confirmación de eliminación masiva en tag-annotation
- Agrega botones "Eliminar esta ocurrencia" y "Eliminar todas las ocurrencias" al popover de anotaciones
- Usa los íconos `delete-one.svg` y `delete-all.svg` ya existentes en `public/button-icons/`
- Conecta con `remove()` y `removeByText()` del contexto `useAnnotation`

Closes #51

## Cambios
- **Nuevo:** `tag-annotation/remove-dialog.tsx` — dialog de confirmación (misma estructura que `replace-dialog.tsx`)
- **Modificado:** `annotation-popover/tagger.tsx` — props opcionales `onDeleteOne`/`onDeleteAll`, botones condicionales
- **Modificado:** `annotation-popover/index.tsx` — pasa las nuevas props al Tagger
- **Modificado:** `tag-annotation/index.tsx` — handlers `handleDeleteOne`, `handleDeleteAll`, `confirmRemoveAll`; estado `removeAllOpen`; renderiza `RemoveDialog`

## Test plan
- [ ] Hover sobre una entidad anotada — aparecen botones de eliminar
- [ ] Click "Eliminar esta ocurrencia" — elimina solo esa anotación, muestra toast
- [ ] Click "Eliminar todas las ocurrencias" — abre dialog de confirmación
- [ ] Confirmar en dialog — elimina todas las ocurrencias del mismo texto, muestra toast
- [ ] Cancelar en dialog — no elimina nada

## Summary by Sourcery

Restore hover delete actions for tag annotations and add confirmation for bulk removals.

New Features:
- Add optional delete-one and delete-all actions to the annotation popover tagger with dedicated icons.
- Introduce a RemoveDialog component to confirm deleting all occurrences of a tagged annotation by matching text.

Enhancements:
- Wire tag annotations to new remove and removeByText operations and show success toasts for single and bulk deletions.
- Update the replace-all dialog copy to clarify that replacements are based on exact text matches and simplify replace-all logic to use text-based updates only.