### PR TITLE
Fix text overflow in HowItWorksModal

### DIFF
--- a/src/renderer/src/components/how-it-works-modal.tsx
+++ b/src/renderer/src/components/how-it-works-modal.tsx
@@ -35,6 +35,8 @@ const closeButton = css({
 
 const content = css({
   minWidth: "[900px]",
+  maxWidth: "[min(900px,90vw)]",
+  overflowY: "auto",
 });
 
 interface HowItWorksModalProps {

--- a/src/renderer/src/components/how-it-works-modal.tsx
+++ b/src/renderer/src/components/how-it-works-modal.tsx
@@ -34,9 +34,9 @@ const closeButton = css({
 });
 
 const content = css({
-  width: "[90vw]",
-  maxWidth: "[1200px]",
   overflowY: "auto",
+  maxH: "[90vh]",
+  maxW: "5xl!",  
 });
 
 interface HowItWorksModalProps {
@@ -61,7 +61,7 @@ export default function HowItWorksModal({ feature }: HowItWorksModalProps) {
         </TooltipTrigger>
         <TooltipContent className={tooltip}>{t("howItWorks")}</TooltipContent>
       </Tooltip>
-      <DialogContent className={content}>
+      <DialogContent className={content} style={{ width: "90vw" }}>
         <Stack gap="0">
           <HowItWorks
             title={

--- a/src/renderer/src/components/how-it-works-modal.tsx
+++ b/src/renderer/src/components/how-it-works-modal.tsx
@@ -34,8 +34,8 @@ const closeButton = css({
 });
 
 const content = css({
-  minWidth: "[900px]",
-  maxWidth: "[min(900px,90vw)]",
+  width: "[90vw]",
+  maxWidth: "[1200px]",
   overflowY: "auto",
 });
 

--- a/src/renderer/src/components/how-it-works.tsx
+++ b/src/renderer/src/components/how-it-works.tsx
@@ -14,6 +14,13 @@ const card = css({
 
   px: "4",
   py: "6",
+
+  "& > img": {
+    width: "[200px]",
+    height: "[130px]",
+    objectFit: "contain",
+    flexShrink: "0",
+  },
 });
 
 const stepStyle = css({
@@ -38,7 +45,7 @@ interface CardProps {
 function Card({ img, imgAlt, step, title, subtitle }: CardProps) {
   return (
     <div className={card}>
-      <img src={img} alt={imgAlt} height="130" />
+      <img src={img} alt={imgAlt} />
       <Stack gap="4">
         <p className={stepStyle}>{step}</p>
         <Stack>

--- a/src/renderer/src/components/how-it-works.tsx
+++ b/src/renderer/src/components/how-it-works.tsx
@@ -71,23 +71,23 @@ export default function HowItWorks({ title, feature }: HowItWorksProps) {
       <Grid columns={2}>
         <Card
           img={`${import.meta.env.BASE_URL}onboarding-steps/step1.png`}
-          imgAlt={t("howItWorksSteps.step1.alt")}
-          title={t("howItWorksSteps.step1.title")}
-          subtitle={t("howItWorksSteps.step1.subtitle")}
+          imgAlt={tFeature("howItWorks.step1.alt")}
+          title={tFeature("howItWorks.step1.title")}
+          subtitle={tFeature("howItWorks.step1.subtitle")}
           step={1}
         />
         <Card
           img={`${import.meta.env.BASE_URL}onboarding-steps/step2.png`}
-          imgAlt={t("howItWorksSteps.step2.alt")}
-          title={t("howItWorksSteps.step2.title")}
-          subtitle={t("howItWorksSteps.step2.subtitle")}
+          imgAlt={tFeature("howItWorks.step2.alt")}
+          title={tFeature("howItWorks.step2.title")}
+          subtitle={tFeature("howItWorks.step2.subtitle")}
           step={2}
         />
         <Card
           img={`${import.meta.env.BASE_URL}onboarding-steps/step3.png`}
-          imgAlt={t("howItWorksSteps.step3.alt")}
-          title={t("howItWorksSteps.step3.title")}
-          subtitle={t("howItWorksSteps.step3.subtitle")}
+          imgAlt={tFeature("howItWorks.step3.alt")}
+          title={tFeature("howItWorks.step3.title")}
+          subtitle={tFeature("howItWorks.step3.subtitle")}
           step={3}
         />
         <Card

--- a/src/renderer/src/constants/i18n/locales/es/anonymizer.ts
+++ b/src/renderer/src/constants/i18n/locales/es/anonymizer.ts
@@ -27,7 +27,7 @@ const anonymizer = {
       alt: "Barra de búsqueda con cursor",
       title: "La inteligencia artificial analiza el documento",
       subtitle:
-        "Reconoce automáticamente la información sensible o identificable que debe protegerse.",
+        "Reconoce automáticamente la información a anonimizar.",
     },
     step3: {
       alt: "Visor de documentos con controles de revisión",

--- a/src/renderer/src/constants/i18n/locales/es/anonymizer.ts
+++ b/src/renderer/src/constants/i18n/locales/es/anonymizer.ts
@@ -18,6 +18,23 @@ const anonymizer = {
     continue: "Continuar",
   },
   howItWorks: {
+    step1: {
+      alt: "Interfaz web con selector y cursor",
+      title: "Selecciona la resolución judicial",
+      subtitle: "Sube el documento que quieres anonimizar.",
+    },
+    step2: { 
+      alt: "Barra de búsqueda con cursor",
+      title: "La inteligencia artificial analiza el documento",
+      subtitle:
+        "Reconoce automáticamente la información sensible o identificable que debe protegerse.",
+    },
+    step3: {
+      alt: "Visor de documentos con controles de revisión",
+      title: "Revisión y validación humana",
+      subtitle:
+        "Es importante que verifiques que los datos sean correctos antes de exportar el archivo.",
+    },
     step4: {
       alt: "Binoculares con globo terráqueo",
       title: "Generación del documento anonimizado",

--- a/src/renderer/src/constants/i18n/locales/es/anonymizer.ts
+++ b/src/renderer/src/constants/i18n/locales/es/anonymizer.ts
@@ -39,7 +39,7 @@ const anonymizer = {
       alt: "Binoculares con globo terráqueo",
       title: "Generación del documento anonimizado",
       subtitle:
-        "Proceso terminado. El documento esta listo para ser exportado.",
+        "Proceso terminado. El documento está listo para ser exportado.",
     },
   },
   process: {

--- a/src/renderer/src/constants/i18n/locales/es/common.ts
+++ b/src/renderer/src/constants/i18n/locales/es/common.ts
@@ -7,13 +7,13 @@ const common = {
       greeting: "¡Hola! Selecciona la herramienta a utilizar",
     },
     host: {
-      howToConnect: "¿Como deseas conectarte a Aymurai?",
+      howToConnect: "¿Cómo deseas conectarte a Aymurai?",
       optionLocal: "Local",
       optionServer: "Servidor",
       optionOr: "o",
       connectServerExplanation:
         "Ingresa la dirección del servidor al que deseas conectarte",
-      connectServerLabel: "Direccion del servidor",
+      connectServerLabel: "Dirección del servidor",
       connectServerSubmit: "Guardar y conectar",
       errors: {
         network: "No se pudo conectar al servidor",

--- a/src/renderer/src/constants/i18n/locales/es/common.ts
+++ b/src/renderer/src/constants/i18n/locales/es/common.ts
@@ -30,25 +30,6 @@ const common = {
     validation: "Validación",
     finalization: "Finalización",
   },
-  howItWorksSteps: {
-    step1: {
-      alt: "Interfaz web con selector y cursor",
-      title: "Selecciona las resoluciones judiciales",
-      subtitle: "Sube los documentos que querés incorporar al set de datos.",
-    },
-    step2: {
-      alt: "Barra de búsqueda con cursor",
-      title: "La inteligencia artificial analiza los documentos",
-      subtitle:
-        "Extrae automáticamente la información relevante de cada documento.",
-    },
-    step3: {
-      alt: "Visor de documentos con controles de revisión",
-      title: "Revisión y validación humana",
-      subtitle:
-        "Es importante que verifiques que los datos sean correctos antes de exportar el archivo",
-    },
-  },
   filePreview: {
     loadError: "No se pudo cargar el archivo",
   },

--- a/src/renderer/src/constants/i18n/locales/es/dataset.ts
+++ b/src/renderer/src/constants/i18n/locales/es/dataset.ts
@@ -18,6 +18,23 @@ const dataset = {
     continue: "Continuar",
   },
   howItWorks: {
+    step1: {
+      alt: "Interfaz web con selector y cursor",
+      title: "Selecciona las resoluciones judiciales",
+      subtitle: "Sube los documentos que quieres incorporar al set de datos.",
+    },
+    step2: {
+      alt: "Barra de búsqueda con cursor",
+      title: "La inteligencia artificial analiza los documentos",
+      subtitle:
+        "Extrae automáticamente la información relevante de cada documento.",
+    },
+    step3: {
+      alt: "Visor de documentos con controles de revisión",
+      title: "Revisión y validación humana",
+      subtitle:
+        "Es importante que verifiques que los datos sean correctos antes de exportar el archivo.",
+    },
     step4: {
       alt: "Binoculares con globo terráqueo",
       title: "Generación del set de datos",


### PR DESCRIPTION
## Summary
- Agrega `maxWidth: min(900px, 90vw)` y `overflowY: auto` al contenido del modal
- En viewports >=900px el modal mantiene 900px de ancho
- En viewports <900px se achica proporcionalmente sin overflow horizontal

Closes #52

## Test plan
- [ ] Abrir el modal "Cómo funciona" en viewport >=900px — texto visible sin overflow
- [ ] Reducir viewport a <900px — modal se adapta sin desbordar

## Summary by Sourcery

Adjust HowItWorks modal layout and i18n content to prevent text overflow and align copy with anonymizer and dataset flows.

Bug Fixes:
- Prevent text overflow in the HowItWorks modal by constraining width and enabling vertical scrolling.

Enhancements:
- Refine HowItWorks card image styling for consistent sizing and layout within the modal.
- Scope HowItWorks step translations to feature-specific namespaces for anonymizer and dataset flows.

Documentation:
- Update Spanish copy for HowItWorks steps and common host labels with corrected wording and accents.