### PR TITLE
Restore home button on features page

### DIFF
--- a/src/renderer/src/components/features-menu.tsx
+++ b/src/renderer/src/components/features-menu.tsx
@@ -1,9 +1,9 @@
-import { Grid, Stack, styled } from "@/styled/jsx";
-import { FeatureFlowEnum, featureNamespace } from "@/types/features";
 import { useFileDispatch } from "@/hooks/useFiles";
 import { removeAllFiles } from "@/reducers/file/actions";
+import { Grid, Stack, styled } from "@/styled/jsx";
+import { FeatureFlowEnum, featureNamespace } from "@/types/features";
 import { Link } from "@tanstack/react-router";
-import { DotsNine } from "phosphor-react";
+import { DotsNine, Gear } from "phosphor-react";
 import { useTranslation } from "react-i18next";
 import FeatureIcon from "./feature-icon";
 import Button from "./ui/button";
@@ -45,6 +45,18 @@ export default function FeaturesMenu() {
               </Card>
             </Link>
           ))}
+          <styled.div gridColumn="span 2">
+            <Link to="/home/host" onClick={handleClearFiles}>
+              <Card size="sm" clickable>
+                <Stack gap="3" align="center">
+                  <FeatureIcon icon={Gear} size="sm" />
+                  <styled.p textStyle="label.md.strong">
+                    {t("settings")}
+                  </styled.p>
+                </Stack>
+              </Card>
+            </Link>
+          </styled.div>
         </Grid>
       </PopoverContent>
     </Popover>

--- a/src/renderer/src/components/layout/header.tsx
+++ b/src/renderer/src/components/layout/header.tsx
@@ -2,6 +2,7 @@ import { useTutorialSeen } from "@/store/useLocal";
 import { css } from "@/styled/css";
 import { Divider, HStack, Stack, styled } from "@/styled/jsx";
 import type { FeatureFlowEnum } from "@/types/features";
+import { Link } from "@tanstack/react-router";
 import FeaturesMenu from "../features-menu";
 import HowItWorksModal from "../how-it-works-modal";
 
@@ -51,20 +52,22 @@ export default function Header({ title, center, feature, right }: HeaderProps) {
 
   return (
     <header className={header}>
-      <Stack gap="4" align="center" direction="row">
-        <img height={40} src={img} alt="AymurAI logo" />
-        {title && (
-          <>
-            <Divider
-              orientation="vertical"
-              thickness="[2px]"
-              color="text.default"
-              height="4"
-            />
-            <styled.span textStyle="subtitle.md.strong">{title}</styled.span>
-          </>
-        )}
-      </Stack>
+      <Link to="/home/features">
+        <Stack gap="4" align="center" direction="row">
+          <img height={40} src={img} alt="AymurAI logo" />
+          {title && (
+            <>
+              <Divider
+                orientation="vertical"
+                thickness="[2px]"
+                color="text.default"
+                height="4"
+              />
+              <styled.span textStyle="subtitle.md.strong">{title}</styled.span>
+            </>
+          )}
+        </Stack>
+      </Link>
       {center && <div className={centerSlot}>{center}</div>}
       {rightSlot}
     </header>

--- a/src/renderer/src/components/layout/header.tsx
+++ b/src/renderer/src/components/layout/header.tsx
@@ -25,14 +25,12 @@ const centerSlot = css({
   transform: "translateX(-50%)",
 });
 
-type HeaderProps = {
+interface HeaderProps {
   title?: string;
   center?: React.ReactNode;
-} & (
-  | { feature: FeatureFlowEnum; right?: never }
-  | { right: React.ReactNode; feature?: never }
-  | { right?: never; feature?: never }
-);
+  feature?: FeatureFlowEnum;
+  right?: React.ReactNode;
+}
 
 export default function Header({ title, center, feature, right }: HeaderProps) {
   const tutorialSeen = useTutorialSeen(feature!);
@@ -40,15 +38,6 @@ export default function Header({ title, center, feature, right }: HeaderProps) {
   const img = title
     ? `${import.meta.env.BASE_URL}brand/aymurai-iso-darkpurple.svg`
     : `${import.meta.env.BASE_URL}brand/aymurai-hor-darkpurple.svg`;
-
-  const rightSlot = feature ? (
-    <HStack>
-      {tutorialSeen && <HowItWorksModal feature={feature} />}
-      <FeaturesMenu />
-    </HStack>
-  ) : (
-    right
-  );
 
   return (
     <header className={header}>
@@ -69,7 +58,11 @@ export default function Header({ title, center, feature, right }: HeaderProps) {
         </Stack>
       </Link>
       {center && <div className={centerSlot}>{center}</div>}
-      {rightSlot}
+      <HStack>
+        {tutorialSeen && feature && <HowItWorksModal feature={feature} />}
+        {right}
+        <FeaturesMenu />
+      </HStack>
     </header>
   );
 }

--- a/src/renderer/src/components/layout/home-button.tsx
+++ b/src/renderer/src/components/layout/home-button.tsx
@@ -1,0 +1,16 @@
+import { css } from "@/styled/css";
+import { House } from "phosphor-react";
+import Link from "../ui/link";
+
+export default function HomeButton() {
+  return (
+    <Link
+      to="/home/features"
+      size="icon-sm"
+      className={css({ p: "0.5" })}
+      aria-label="Volver al inicio"
+    >
+      <House size={32} />
+    </Link>
+  );
+}

--- a/src/renderer/src/components/ui/button.tsx
+++ b/src/renderer/src/components/ui/button.tsx
@@ -30,17 +30,17 @@ export const button = cva({
         bg: "action.default",
         color: "text.onbutton-default",
 
-        "&:hover:enabled": {
+        "&:hover:not(:disabled)": {
           bg: "action.hover",
           color: "text.onbutton-alternative",
         },
 
-        "&:active:enabled": {
+        "&:active:not(:disabled)": {
           bg: "action.pressed",
           color: "text.onbutton-alternative",
         },
 
-        "&:focus:enabled": {
+        "&:focus:not(:disabled)": {
           bg: "action.focus",
           outline: "primary-alt",
           outlineWidth: "[2px]",
@@ -60,19 +60,19 @@ export const button = cva({
         borderStyle: "solid",
         borderColor: "action.alt-default",
 
-        "&:hover:enabled": {
+        "&:hover:not(:disabled)": {
           color: "text.onbutton-default",
           bg: "bg.secondary",
           borderColor: "action.hover",
         },
 
-        "&:active:enabled": {
+        "&:active:not(:disabled)": {
           color: "text.onbutton-alternative",
           bg: "action.pressed",
           borderColor: "action.pressed",
         },
 
-        "&:focus:enabled": {
+        "&:focus:not(:disabled)": {
           boxShadow: "[0px 0px 10px rgba(17, 0, 65, 0.2)]",
           outline: "primary-alt",
           outlineWidth: "[2px]",

--- a/src/renderer/src/components/ui/button.tsx
+++ b/src/renderer/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import { type RecipeVariantProps, css, cva, cx } from "@/styled/css";
 import { CircleNotch } from "phosphor-react";
 import type { ButtonHTMLAttributes } from "react";
 
-const button = cva({
+export const button = cva({
   base: {
     display: "flex",
     flexDir: "row",
@@ -124,7 +124,7 @@ type ButtonProps = RecipeVariantProps<typeof button> &
     isLoading?: boolean;
   };
 
-function Button({
+export default function Button({
   size,
   variant,
   isLoading,
@@ -148,5 +148,3 @@ function Button({
     </button>
   );
 }
-
-export default Button;

--- a/src/renderer/src/components/ui/link.tsx
+++ b/src/renderer/src/components/ui/link.tsx
@@ -1,0 +1,33 @@
+import { type RecipeVariantProps, css, cx } from "@/styled/css";
+import { Link as TanstackLink, type LinkProps as TanstackLinkProps } from "@tanstack/react-router";
+import { CircleNotch } from "phosphor-react";
+import { button } from "./button";
+
+type LinkProps = RecipeVariantProps<typeof button> &
+  TanstackLinkProps & {
+    isLoading?: boolean;
+    className?: string;
+  };
+
+export default function Link({
+  size,
+  variant,
+  checked,
+  isLoading,
+  children,
+  className,
+  ...props
+}: LinkProps) {
+  return (
+    <TanstackLink
+      {...props}
+      className={cx(button({ size, variant, checked }), className)}
+    >
+      {isLoading ? (
+        <CircleNotch className={css({ animation: "spin" })} />
+      ) : (
+        children
+      )}
+    </TanstackLink>
+  );
+}

--- a/src/renderer/src/constants/i18n/locales/es/common.ts
+++ b/src/renderer/src/constants/i18n/locales/es/common.ts
@@ -2,6 +2,7 @@ const common = {
   back: "Volver",
   howItWorks: "¿Cómo funciona?",
   platformBuiltBy: "Plataforma hecha por",
+  settings: "Configuración",
   home: {
     features: {
       greeting: "¡Hola! Selecciona la herramienta a utilizar",

--- a/src/renderer/src/routes/app.$feature/finish.tsx
+++ b/src/renderer/src/routes/app.$feature/finish.tsx
@@ -1,14 +1,11 @@
-import FeaturesMenu from "@/components/features-menu";
 import FinishAnonymizer from "@/components/finish/finish-anonymizer";
 import FinishDataset from "@/components/finish/finish-dataset";
 import Stepper from "@/components/home/stepper";
-import HowItWorksModal from "@/components/how-it-works-modal";
 import Header from "@/components/layout/header";
+import HomeButton from "@/components/layout/home-button";
 import RequireFile from "@/features/RequireFile";
 import { useFileDispatch } from "@/hooks";
 import { removeAllFiles } from "@/reducers/file/actions";
-import { useTutorialSeen } from "@/store/useLocal";
-import { HStack } from "@/styled/jsx";
 import { FeatureFlowEnum, featureNamespace } from "@/types/features";
 import {
   createFileRoute,
@@ -27,7 +24,6 @@ function RouteComponent() {
   const { feature } = params;
 
   const { t } = useTranslation(featureNamespace[feature]);
-  const tutorialSeen = useTutorialSeen(feature);
   const dispatch = useFileDispatch();
 
   const handleRestart = () => {
@@ -44,12 +40,7 @@ function RouteComponent() {
             <Stepper currentStep={4} />
           ) : undefined
         }
-        right={
-          <HStack>
-            {tutorialSeen && <HowItWorksModal feature={feature} />}
-            <FeaturesMenu />
-          </HStack>
-        }
+        right={<HomeButton />}
       />
 
       {feature === FeatureFlowEnum.Dataset ? (

--- a/src/renderer/src/routes/app.$feature/onboarding.tsx
+++ b/src/renderer/src/routes/app.$feature/onboarding.tsx
@@ -9,6 +9,7 @@ import HiddenInput from "@/components/hidden-input";
 import HowItWorks from "@/components/how-it-works";
 import Footer from "@/components/layout/footer";
 import Header from "@/components/layout/header";
+import HomeButton from "@/components/layout/home-button";
 import MainContent from "@/components/layout/main-content";
 import BackButton from "@/components/ui/back-button";
 import Button from "@/components/ui/button";
@@ -66,7 +67,7 @@ function RouteComponent() {
 
   return (
     <>
-      <Header title={t("title")} feature={feature} />
+      <Header title={t("title")} feature={feature} right={<HomeButton />} />
       <MainContent>
         {tutorialSeen ? (
           <Stack gap="8">

--- a/src/renderer/src/routes/app.$feature/preview.tsx
+++ b/src/renderer/src/routes/app.$feature/preview.tsx
@@ -3,6 +3,7 @@ import HiddenInput from "@/components/hidden-input";
 import Stepper from "@/components/home/stepper";
 import Footer from "@/components/layout/footer";
 import Header from "@/components/layout/header";
+import HomeButton from "@/components/layout/home-button";
 import MainContent from "@/components/layout/main-content";
 import BackButton from "@/components/ui/back-button";
 import Card from "@/components/ui/card";
@@ -71,6 +72,7 @@ function RouteComponent() {
         title={t("title")}
         center={<Stepper currentStep={1} />}
         feature={feature}
+        right={<HomeButton />}
       />
       <MainContent>
         <Stack gap="8">
@@ -88,7 +90,9 @@ function RouteComponent() {
                   <FilePreview
                     key={file.data.name}
                     file={file}
-                    status={parseStatuses[file.data.name]?.status ?? "processing"}
+                    status={
+                      parseStatuses[file.data.name]?.status ?? "processing"
+                    }
                   />
                 ))}
               </Grid>

--- a/src/renderer/src/routes/app.$feature/process.tsx
+++ b/src/renderer/src/routes/app.$feature/process.tsx
@@ -2,6 +2,7 @@ import { Button, FileProcessing } from "@/components";
 import Stepper from "@/components/home/stepper";
 import Footer from "@/components/layout/footer";
 import Header from "@/components/layout/header";
+import HomeButton from "@/components/layout/home-button";
 import MainContent from "@/components/layout/main-content";
 import BackButton from "@/components/ui/back-button";
 import Callout from "@/components/ui/callout";
@@ -13,12 +14,12 @@ import { useFileParse } from "@/hooks/useFileParse";
 import { type PredictStatus, usePredict } from "@/hooks/usePredict";
 import { SectionTitle } from "@/layout/section-title";
 import { filterUnprocessed } from "@/reducers/file/actions";
+import taskbar from "@/services/taskbar";
 import { css } from "@/styled/css";
 import { HStack, Stack, styled } from "@/styled/jsx";
 import type { Workflows } from "@/types/aymurai";
 import { FeatureFlowEnum, featureNamespace } from "@/types/features";
 import type { DocFile } from "@/types/file";
-import taskbar from "@/services/taskbar";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   createFileRoute,
@@ -123,6 +124,7 @@ function RouteComponent() {
         title={t("title")}
         feature={feature}
         center={<Stepper currentStep={2} />}
+        right={<HomeButton />}
       />
       <MainContent>
         <Stack gap="10">

--- a/src/renderer/src/routes/app.$feature/validation.tsx
+++ b/src/renderer/src/routes/app.$feature/validation.tsx
@@ -2,6 +2,7 @@ import { Button, FileAnnotator, ValidateDataset } from "@/components";
 import Stepper from "@/components/home/stepper";
 import Footer from "@/components/layout/footer";
 import Header from "@/components/layout/header";
+import HomeButton from "@/components/layout/home-button";
 import RequireFile from "@/features/RequireFile";
 import { useFiles } from "@/hooks";
 import { Grid, Stack } from "@/styled/jsx";
@@ -37,6 +38,7 @@ function RouteComponent() {
           title={t("title")}
           center={<Stepper currentStep={3} />}
           feature={feature}
+          right={<HomeButton />}
         />
         <Grid
           columns={1}

--- a/src/renderer/src/routes/home/features.tsx
+++ b/src/renderer/src/routes/home/features.tsx
@@ -3,7 +3,7 @@ import FeatureIcon from "@/components/feature-icon";
 import FeaturesMenu from "@/components/features-menu";
 import Header from "@/components/layout/header";
 import MainContent from "@/components/layout/main-content";
-import BackButton from "@/components/ui/back-button";
+import Button from "@/components/ui/button";
 import Card from "@/components/ui/card";
 import APIProtected from "@/features/APIProtected";
 import { css } from "@/styled/css";
@@ -14,8 +14,9 @@ import {
   Link,
   type LinkComponentProps,
   createFileRoute,
+  useNavigate,
 } from "@tanstack/react-router";
-import type { Icon } from "phosphor-react";
+import { House, type Icon } from "phosphor-react";
 import { useTranslation } from "react-i18next";
 
 const builtBy = css({
@@ -61,19 +62,31 @@ export const Route = createFileRoute("/home/features")({
 
 function RouteComponent() {
   const { t } = useTranslation(["common", "dataset", "anonymizer"]);
+  const navigate = useNavigate();
 
   return (
     <APIProtected>
       <Stack width="screen" height="screen" gap="0">
-        <Header right={<FeaturesMenu />} />
+        <Header
+          right={
+            <HStack gap="2">
+              <Button
+                size="icon-sm"
+                style={{ padding: 2 }}
+                aria-label="Volver al inicio"
+                onClick={() => navigate({ to: "/home/host" })}
+              >
+                <House size={32} />
+              </Button>
+              <FeaturesMenu />
+            </HStack>
+          }
+        />
         <MainContent>
           <Stack gap="6">
-            <HStack alignItems="center" gap="4">
-              <BackButton to="/home/host" aria-label="Volver al inicio" />
-              <styled.h1 textStyle="title.md.strong">
-                {t("home.features.greeting")}
-              </styled.h1>
-            </HStack>
+            <styled.h1 textStyle="title.md.strong">
+              {t("home.features.greeting")}
+            </styled.h1>
             <Grid columns={2} rowGap="6" columnGap="6">
               {/* FIXME: fix the text wrapping on smaller screens */}
               <CardTool

--- a/src/renderer/src/routes/home/features.tsx
+++ b/src/renderer/src/routes/home/features.tsx
@@ -1,22 +1,19 @@
 import BuiltBy from "@/components/brand/built-by";
 import FeatureIcon from "@/components/feature-icon";
-import FeaturesMenu from "@/components/features-menu";
 import Header from "@/components/layout/header";
 import MainContent from "@/components/layout/main-content";
-import Button from "@/components/ui/button";
 import Card from "@/components/ui/card";
 import APIProtected from "@/features/APIProtected";
 import { css } from "@/styled/css";
-import { Grid, HStack, Stack, styled } from "@/styled/jsx";
+import { Grid, Stack, styled } from "@/styled/jsx";
 import { FeatureFlowEnum } from "@/types/features";
 import { FEATURE_ICON } from "@/utils/config";
 import {
   Link,
   type LinkComponentProps,
   createFileRoute,
-  useNavigate,
 } from "@tanstack/react-router";
-import { House, type Icon } from "phosphor-react";
+import type { Icon } from "phosphor-react";
 import { useTranslation } from "react-i18next";
 
 const builtBy = css({
@@ -62,33 +59,17 @@ export const Route = createFileRoute("/home/features")({
 
 function RouteComponent() {
   const { t } = useTranslation(["common", "dataset", "anonymizer"]);
-  const navigate = useNavigate();
 
   return (
     <APIProtected>
       <Stack width="screen" height="screen" gap="0">
-        <Header
-          right={
-            <HStack gap="4">
-              <Button
-                size="icon-sm"
-                style={{ padding: 2 }}
-                aria-label="Volver al inicio"
-                onClick={() => navigate({ to: "/home/host" })}
-              >
-                <House size={32} />
-              </Button>
-              <FeaturesMenu />
-            </HStack>
-          }
-        />
+        <Header />
         <MainContent>
           <Stack gap="6">
             <styled.h1 textStyle="title.md.strong">
               {t("home.features.greeting")}
             </styled.h1>
             <Grid columns={2} rowGap="6" columnGap="6">
-              {/* FIXME: fix the text wrapping on smaller screens */}
               <CardTool
                 to="/app/$feature"
                 params={{ feature: FeatureFlowEnum.Dataset }}

--- a/src/renderer/src/routes/home/features.tsx
+++ b/src/renderer/src/routes/home/features.tsx
@@ -69,7 +69,7 @@ function RouteComponent() {
       <Stack width="screen" height="screen" gap="0">
         <Header
           right={
-            <HStack gap="2">
+            <HStack gap="4">
               <Button
                 size="icon-sm"
                 style={{ padding: 2 }}

--- a/src/renderer/src/routes/home/features.tsx
+++ b/src/renderer/src/routes/home/features.tsx
@@ -3,10 +3,11 @@ import FeatureIcon from "@/components/feature-icon";
 import FeaturesMenu from "@/components/features-menu";
 import Header from "@/components/layout/header";
 import MainContent from "@/components/layout/main-content";
+import BackButton from "@/components/ui/back-button";
 import Card from "@/components/ui/card";
 import APIProtected from "@/features/APIProtected";
 import { css } from "@/styled/css";
-import { Grid, Stack, styled } from "@/styled/jsx";
+import { Grid, HStack, Stack, styled } from "@/styled/jsx";
 import { FeatureFlowEnum } from "@/types/features";
 import { FEATURE_ICON } from "@/utils/config";
 import {
@@ -67,9 +68,12 @@ function RouteComponent() {
         <Header right={<FeaturesMenu />} />
         <MainContent>
           <Stack gap="6">
-            <styled.h1 textStyle="title.md.strong">
-              {t("home.features.greeting")}
-            </styled.h1>
+            <HStack alignItems="center" gap="4">
+              <BackButton to="/home/host" aria-label="Volver al inicio" />
+              <styled.h1 textStyle="title.md.strong">
+                {t("home.features.greeting")}
+              </styled.h1>
+            </HStack>
             <Grid columns={2} rowGap="6" columnGap="6">
               {/* FIXME: fix the text wrapping on smaller screens */}
               <CardTool


### PR DESCRIPTION
## Summary
- Agrega un botón Home (ícono casa) en el header de `/home/features`, junto al FeaturesMenu existente
- Navega a `/home/host` (pantalla de selección Local/Servidor)
- Usa el componente existente de ícono `House` de Phosphor React, consistente con el estilo del FeaturesMenu

Closes #53

## Test plan
- [ ] En `/home/features`, verificar que aparece el ícono de casa arriba a la derecha, junto al menú de features
- [ ] Hacer click en el ícono — navega a `/home/host`

## Summary by Sourcery

New Features:
- Add a home icon button to the /home/features header that navigates to the /home/host screen.