### PR TITLE
Conversion endpoint usage

### DIFF
--- a/src/renderer/src/components/finish/finish-anonymizer.tsx
+++ b/src/renderer/src/components/finish/finish-anonymizer.tsx
@@ -3,6 +3,7 @@ import { aymuraiService } from "@/services/aymurai";
 import { useExcludedTagsConfig } from "@/store/useLocal";
 import { HStack } from "@/styled/jsx";
 import { FeatureFlowEnum } from "@/types/features";
+import { showToast } from "@/features/showToast";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import FileCheck from "../file-check";
@@ -37,6 +38,11 @@ export default function FinishAnonymizer({ onRestart }: FinishAnonymizerProps) {
     aymuraiService.pdfToOdt(),
   );
 
+  const onConversionError = (error: Error) => {
+    console.error("Conversion failed:", error);
+    showToast(t("finish.downloadError"), "error");
+  };
+
   const downloadDocument = () => {
     if (!anonymizedFile) {
       console.error("Tried to download a file that is not ready.");
@@ -48,6 +54,7 @@ export default function FinishAnonymizer({ onRestart }: FinishAnonymizerProps) {
         onSuccess: (odtBlob) => {
           triggerDownload(odtBlob, changeExtension(file.data.name));
         },
+        onError: onConversionError,
       });
     } else {
       triggerDownload(anonymizedFile, changeExtension(file.data.name));
@@ -67,6 +74,7 @@ export default function FinishAnonymizer({ onRestart }: FinishAnonymizerProps) {
         onSuccess: (pdfBlob) => {
           triggerDownload(pdfBlob, changeExtension(file.data.name, "pdf"));
         },
+        onError: onConversionError,
       });
     }
   };

--- a/src/renderer/src/components/finish/finish-anonymizer.tsx
+++ b/src/renderer/src/components/finish/finish-anonymizer.tsx
@@ -13,6 +13,7 @@ import FinishMainContent from "./finish-main-content";
 interface FinishAnonymizerProps {
   onRestart: () => void;
 }
+
 export default function FinishAnonymizer({ onRestart }: FinishAnonymizerProps) {
   const { t } = useTranslation("anonymizer");
   const file = useFiles().at(0);
@@ -20,8 +21,10 @@ export default function FinishAnonymizer({ onRestart }: FinishAnonymizerProps) {
 
   if (!file) throw new Error("Reached /finish but there's no file to read");
 
+  const isPdfInput = getExtension(file.data.name) === "pdf";
+
   const {
-    data: odtFile,
+    data: anonymizedFile,
     isLoading,
     isError,
   } = useQuery(aymuraiService.anonymize(file, tags, words));
@@ -30,25 +33,42 @@ export default function FinishAnonymizer({ onRestart }: FinishAnonymizerProps) {
     aymuraiService.odtToPdf(),
   );
 
+  const { mutate: convertToOdt, isPending: isOdtPending } = useMutation(
+    aymuraiService.pdfToOdt(),
+  );
+
   const downloadDocument = () => {
-    if (!odtFile) {
+    if (!anonymizedFile) {
       console.error("Tried to download a file that is not ready.");
       return;
     }
-    triggerDownload(odtFile, changeExtension(file.data.name));
+
+    if (isPdfInput) {
+      convertToOdt(anonymizedFile, {
+        onSuccess: (odtBlob) => {
+          triggerDownload(odtBlob, changeExtension(file.data.name));
+        },
+      });
+    } else {
+      triggerDownload(anonymizedFile, changeExtension(file.data.name));
+    }
   };
 
   const downloadPdf = () => {
-    if (!odtFile) {
+    if (!anonymizedFile) {
       console.error("Tried to download a file that is not ready.");
       return;
     }
 
-    convertToPdf(odtFile, {
-      onSuccess: (pdfBlob) => {
-        triggerDownload(pdfBlob, changeExtension(file.data.name, "pdf"));
-      },
-    });
+    if (isPdfInput) {
+      triggerDownload(anonymizedFile, changeExtension(file.data.name, "pdf"));
+    } else {
+      convertToPdf(anonymizedFile, {
+        onSuccess: (pdfBlob) => {
+          triggerDownload(pdfBlob, changeExtension(file.data.name, "pdf"));
+        },
+      });
+    }
   };
 
   return (
@@ -68,7 +88,7 @@ export default function FinishAnonymizer({ onRestart }: FinishAnonymizerProps) {
           <Button
             onClick={downloadDocument}
             disabled={isError}
-            isLoading={isLoading}
+            isLoading={isLoading || isOdtPending}
           >
             {t("finish.viewResult")}
           </Button>
@@ -83,6 +103,10 @@ export default function FinishAnonymizer({ onRestart }: FinishAnonymizerProps) {
       </Footer>
     </>
   );
+}
+
+function getExtension(name: string) {
+  return name.split(".").pop()?.toLowerCase() ?? "";
 }
 
 function triggerDownload(blob: Blob, fileName: string) {

--- a/src/renderer/src/constants/i18n/locales/es/anonymizer.ts
+++ b/src/renderer/src/constants/i18n/locales/es/anonymizer.ts
@@ -46,6 +46,7 @@ const anonymizer = {
     restart: "Cargar un nuevo documento",
     viewResult: "Descargar ODT",
     viewResultPDF: "Descargar PDF",
+    downloadError: "Ocurrió un error al generar el archivo. Por favor, intente nuevamente.",
   },
 };
 

--- a/src/renderer/src/services/aymurai/queries.ts
+++ b/src/renderer/src/services/aymurai/queries.ts
@@ -179,3 +179,25 @@ export const odtToPdf = () =>
       return response.data;
     },
   });
+
+export const pdfToOdt = () =>
+  mutationOptions({
+    mutationFn: async (file: Blob) => {
+      const formData = new FormData();
+      formData.append("file", file, "document.pdf");
+
+      const response = await api.post<Blob>(
+        "/convert/pdf/odt",
+        formData,
+        {
+          headers: {
+            "Content-Type": "multipart/form-data",
+            Accept: "application/octet-stream",
+          },
+          responseType: "blob",
+        },
+      );
+
+      return response.data;
+    },
+  });


### PR DESCRIPTION
## Summary by Sourcery

Handle anonymization downloads differently based on whether the input file is PDF or ODT, and wire the UI to use the appropriate conversion endpoints.

New Features:
- Add backend mutation and UI flow to convert anonymized PDF files to ODT via a new /convert/pdf/odt endpoint.
- Allow direct download of anonymized PDFs without intermediate ODT conversion when the input is already a PDF.

Enhancements:
- Generalize the finish anonymizer component to treat the anonymization result as a generic file, deciding at download time whether format conversion is required.
- Update loading state handling on the result button to reflect both anonymization and any pending PDF-to-ODT conversion.