### PR TITLE
Set placeholder on Tagger's select

### DIFF
--- a/src/renderer/src/components/file/annotation-popover/tagger-button.tsx
+++ b/src/renderer/src/components/file/annotation-popover/tagger-button.tsx
@@ -8,7 +8,7 @@ import { sva } from "@/styled/css";
 import { styled } from "@/styled/jsx";
 
 const button = sva({
-  slots: ["button", "tooltip_content"],
+  slots: ["button", "tooltipContent"],
   base: {
     button: {
       p: "0.5",
@@ -19,7 +19,7 @@ const button = sva({
         bg: "action.hover",
       },
     },
-    tooltip_content: {
+    tooltipContent: {
       bg: "action.hover",
       color: "white",
       px: "1",
@@ -69,7 +69,7 @@ export default function TaggerButton({
           </button>
         </TooltipTrigger>
         <TooltipContent showArrow={false} sideOffset={12}>
-          <div className={classes.tooltip_content}>
+          <div className={classes.tooltipContent}>
             <styled.p textStyle="label.sm.default">{tooltip}</styled.p>
           </div>
         </TooltipContent>

--- a/src/renderer/src/components/file/annotation-popover/tagger.tsx
+++ b/src/renderer/src/components/file/annotation-popover/tagger.tsx
@@ -10,12 +10,19 @@ import Select, { type SelectOption } from "@/components/ui/select";
 import { useAnnotation } from "@/context/Annotation";
 import { type AllLabels, anonymizerLabels } from "@/types/aymurai";
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
 import TaggerButton from "./tagger-button";
 
 const IMG_SIZE = 24;
 
 const tagger = sva({
-  slots: ["container", "button", "divider"],
+  slots: ["container", "button", "divider", "tooltipContent"],
   base: {
     container: {
       ...hstack.raw({ alignItems: "center", gap: "1" }),
@@ -33,6 +40,13 @@ const tagger = sva({
 
       my: "1",
     },
+    tooltipContent: {
+      bg: "action.hover",
+      color: "white",
+      px: "1",
+      py: "0.5",
+      rounded: "sm",
+    },
   },
 });
 
@@ -45,6 +59,7 @@ export default function Tagger({ onClickAll, onClickOne }: MarkTaggerProps) {
 
   const [label, setLabel] = useState<AllLabels | null>(initialLabel);
   const [suffix, setSuffix] = useState<number | null>(initialSuffix);
+  const [isSelectOpen, setIsSelectOpen] = useState(false);
 
   const handleClickOne = () => {
     if (!label) return;
@@ -69,23 +84,49 @@ export default function Tagger({ onClickAll, onClickOne }: MarkTaggerProps) {
   const classes = tagger();
   return (
     <div className={classes.container}>
-      <Select
-        placeholder="Entidad"
-        size="sm"
-        value={label ?? undefined}
-        options={anonymizerLabels}
-        onChange={handleLabelChange}
-      />
+      <TooltipProvider delayDuration={0}>
+        <Tooltip open={isSelectOpen ? false : undefined}>
+          <TooltipTrigger asChild>
+            <div>
+              <Select
+                placeholder="Etiqueta"
+                size="sm"
+                value={label ?? undefined}
+                options={anonymizerLabels}
+                onChange={handleLabelChange}
+                onOpenChange={setIsSelectOpen}
+              />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent showArrow={false} sideOffset={12}>
+            <div className={classes.tooltipContent}>
+              <styled.p textStyle="label.sm.default">Selecciona tipo de etiqueta</styled.p>
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
       <div className={classes.divider} />
-      <styled.div maxWidth="16">
-        <Input
-          value={suffix ? suffix.toString() : undefined}
-          size="sm"
-          onChange={handleSuffixChange}
-          type="number"
-          min="1"
-        />
-      </styled.div>
+      <TooltipProvider delayDuration={0}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <styled.div maxWidth="16">
+              <Input
+                placeholder="Sufijo"
+                value={suffix ? suffix.toString() : undefined}
+                size="sm"
+                onChange={handleSuffixChange}
+                type="number"
+                min="1"
+              />
+            </styled.div>
+          </TooltipTrigger>
+          <TooltipContent showArrow={false} sideOffset={12}>
+            <div className={classes.tooltipContent}>
+              <styled.p textStyle="label.sm.default">Agrega sufijo si es necesario</styled.p>
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
       <div className={classes.divider} />
       <TaggerButton
         tooltip="Afectar una ocurrencia"

--- a/src/renderer/src/components/file/annotation-popover/tagger.tsx
+++ b/src/renderer/src/components/file/annotation-popover/tagger.tsx
@@ -70,6 +70,7 @@ export default function Tagger({ onClickAll, onClickOne }: MarkTaggerProps) {
   return (
     <div className={classes.container}>
       <Select
+        placeholder="Entidad"
         size="sm"
         value={label ?? undefined}
         options={anonymizerLabels}

--- a/src/renderer/src/components/ui/select.tsx
+++ b/src/renderer/src/components/ui/select.tsx
@@ -23,6 +23,7 @@ interface SelectProps {
   label?: string;
   value?: string;
   onChange?: (value: SelectOption) => void;
+  onOpenChange?: (open: boolean) => void;
   prefix?: string;
   suffix?: string;
   suggestion?: SelectSuggestion;
@@ -108,7 +109,7 @@ const select = sva({
       color: "text.default",
       transition: "[transform 0.15s ease]",
 
-      "[data-state='open'] &": {
+      "[data-state='open'] > &": {
         transform: "[rotate(180deg)]",
       },
     },
@@ -184,6 +185,7 @@ export default function Select({
   label,
   value,
   onChange,
+  onOpenChange,
   prefix,
   suffix,
   suggestion,
@@ -233,6 +235,7 @@ export default function Select({
       <RadixSelect.Root
         value={value}
         onValueChange={handleChange}
+        onOpenChange={onOpenChange}
         disabled={disabled}
       >
         <RadixSelect.Trigger id={triggerId} asChild>


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Introduce a placeholder text for the Tagger component's select control to guide users before selection.