### PR TITLE
Remove support for .doc files

### DIFF
--- a/src/renderer/src/constants/config.ts
+++ b/src/renderer/src/constants/config.ts
@@ -3,4 +3,4 @@ export const DATAGENERO_URL = "https://www.datagenero.org/";
 /**
  * Only allow these extensions to be analyzed
  */
-export const WHITELISTED_EXTENSIONS = ["doc", "docx", "pdf"];
+export const WHITELISTED_EXTENSIONS = ["docx", "pdf"];

--- a/src/renderer/src/constants/i18n/locales/es/anonymizer.ts
+++ b/src/renderer/src/constants/i18n/locales/es/anonymizer.ts
@@ -1,19 +1,21 @@
 import { WHITELISTED_EXTENSIONS } from "@/constants/config";
 
+const validExtensions = WHITELISTED_EXTENSIONS.map((e) => `.${e}`).join(", ");
+
 const anonymizer = {
   title: "Anonimizador",
   subtitle: "Anonimiza resoluciones judiciales de manera automática y editable",
   onboarding: {
     sectionTitle: "1. Selección de Archivo",
-    validFormats: "Formatos válidos: .doc y .docx",
+    validFormats: `Formatos válidos: ${validExtensions}`,
     loadDocuments: "Cargar documentos",
     dropAreaTitle: "Selecciona el archivo para anonimizar",
-    dropAreaFormats: `Formatos válidos: ${WHITELISTED_EXTENSIONS.map((e) => `.${e}`).join(", ")}`,
+    dropAreaFormats: `Formatos válidos: ${validExtensions}`,
   },
   preview: {
     sectionTitle: "1. Selección de Archivo",
     filesLabel: "Archivos seleccionados",
-    validFormats: "Formatos válidos: .doc y .docx",
+    validFormats: `Formatos válidos: ${validExtensions}`,
     loadMore: "Cargar más documentos",
     continue: "Continuar",
   },
@@ -46,7 +48,8 @@ const anonymizer = {
     restart: "Cargar un nuevo documento",
     viewResult: "Descargar ODT",
     viewResultPDF: "Descargar PDF",
-    downloadError: "Ocurrió un error al generar el archivo. Por favor, intente nuevamente.",
+    downloadError:
+      "Ocurrió un error al generar el archivo. Por favor, intente nuevamente.",
   },
 };
 

--- a/src/renderer/src/constants/i18n/locales/es/dataset.ts
+++ b/src/renderer/src/constants/i18n/locales/es/dataset.ts
@@ -1,19 +1,21 @@
 import { WHITELISTED_EXTENSIONS } from "@/constants/config";
 
+const validExtensions = WHITELISTED_EXTENSIONS.map((e) => `.${e}`).join(", ");
+
 const dataset = {
   title: "Set de datos",
   subtitle: "Convierte resoluciones judiciales en set de datos estructurados",
   onboarding: {
     sectionTitle: "1. Selección de Archivos",
-    validFormats: "Formatos válidos: .doc y .docx",
+    validFormats: `Formatos válidos: ${validExtensions}`,
     loadDocuments: "Cargar documentos",
     dropAreaTitle: "Selecciona el archivo para\nagregar a la base de datos",
-    dropAreaFormats: `Formatos válidos: ${WHITELISTED_EXTENSIONS.map((e) => `.${e}`).join(", ")}`,
+    dropAreaFormats: `Formatos válidos: ${validExtensions}`,
   },
   preview: {
     sectionTitle: "1. Selección de Archivos",
     filesLabel: "Archivos seleccionados",
-    validFormats: "Formatos válidos: .doc y .docx",
+    validFormats: `Formatos válidos: ${validExtensions}`,
     loadMore: "Cargar más documentos",
     continue: "Continuar",
   },

--- a/src/renderer/src/types/file.ts
+++ b/src/renderer/src/types/file.ts
@@ -12,7 +12,7 @@ export interface Paragraph {
  */
 export type DocFile = {
   /**
-   * .docx file contents
+   * File contents
    */
   data: File;
   /**


### PR DESCRIPTION
## Summary by Sourcery

Update supported document extensions and related Spanish UI text to reflect removal of .doc support.

Enhancements:
- Derive valid file extension labels from the centralized whitelist config to keep UI messaging in sync with allowed formats.
- Relax the DocFile type comment to be generic to any supported file content.