### PR TITLE
fix(file-annotator): fix upward autoscroll on search previous navigation

### DIFF
--- a/src/renderer/src/components/file-annotator/index.tsx
+++ b/src/renderer/src/components/file-annotator/index.tsx
@@ -170,13 +170,23 @@ export default function FileAnnotator({ file, isAnnotable = false }: Props) {
     if (!activeSearchMatchId) return;
 
     const timer = window.setTimeout(() => {
-      const element = document.querySelector<HTMLElement>(
-        `[data-search-match-id="${activeSearchMatchId}"]`,
-      );
-      element?.scrollIntoView({
+      const container = fileRef.current;
+      const element = Array.from(
+        container?.querySelectorAll<HTMLElement>("[data-search-match-id]") ?? [],
+      ).find((el) => el.getAttribute("data-search-match-id") === activeSearchMatchId);
+      if (!element || !container) return;
+
+      const containerRect = container.getBoundingClientRect();
+      const elementRect = element.getBoundingClientRect();
+      const scrollOffset =
+        elementRect.top -
+        containerRect.top -
+        containerRect.height / 2 +
+        elementRect.height / 2;
+
+      container.scrollBy({
+        top: scrollOffset,
         behavior: "smooth",
-        block: "center",
-        inline: "nearest",
       });
     }, 50);
 


### PR DESCRIPTION
## Problema
Al buscar una palabra y navegar entre las ocurrencias, el botón de "subir" no hacía nada, solo el botón de "bajar" disparaba el autoscroll hacia la ocurrencia correspondiente.

La causa raíz tenía dos partes:
1. La lógica de scroll usaba `element.scrollIntoView()`, que puede fallar silenciosamente al desplazarse hacia arriba dentro de un contenedor `overflow-y: scroll` en el renderer de Electron/Chromium.
2. El `paragraph.id` usa el texto completo del párrafo como identificador, por lo que `querySelector('[data-search-match-id="..."]')` lanzaba un `SyntaxError` cuando el texto contenía caracteres especiales de CSS (`"`, `/`, `,`, etc.).

## Solución
- Se reemplazó `scrollIntoView` por un cálculo explícito con `container.scrollBy()` usando `fileRef`, garantizando un scroll confiable en ambas direcciones.
- Se reemplazó la búsqueda por selector CSS por una comparación de atributo en el DOM (`querySelectorAll` + `getAttribute`), haciendo la búsqueda robusta sin importar los caracteres especiales en el ID del match.

## Issue relacionado
Issue #69

## Summary by Sourcery

Ensure the file annotator reliably auto-scrolls to the active search match when navigating between occurrences.

Bug Fixes:
- Fix upward auto-scroll when navigating to the previous search match in the file annotator search results.
- Handle search match lookup robustly when match IDs contain characters that break CSS attribute selectors.