### PR TITLE
Fix/homogenize file check ui

### DIFF
--- a/src/renderer/src/components/file-check/FileCheck.styles.ts
+++ b/src/renderer/src/components/file-check/FileCheck.styles.ts
@@ -11,10 +11,7 @@ export const Wrapper = styled("div", {
   position: "relative",
 
   // Settings to enable ellipsis on file name
-  maxWidth: 131,
-  "@xl": {
-    maxWidth: 175,
-  },
+  maxWidth: 150,
   "& p": {
     overflow: "hidden",
     textOverflow: "ellipsis",
@@ -30,22 +27,8 @@ export const Card = styled("div", {
   justifyContent: "center",
   alignItems: "center",
 
-  height: 150,
-  width: 113,
-
-  "@xl": {
-    height: 200,
-    width: 150,
-    "& svg": {
-      width: 48,
-      height: 48,
-    },
-  },
-
-  "& svg": {
-    width: 36,
-    height: 36,
-  },
+  height: 200,
+  width: 150,
 
   borderWidth: "$sizes$xs",
   borderStyle: "solid",

--- a/src/renderer/src/components/file-check/index.tsx
+++ b/src/renderer/src/components/file-check/index.tsx
@@ -20,7 +20,7 @@ export default function FileCheck({
       <Card {...{ hasError }}>
         <Icon {...{ hasError, isLoading }} />
       </Card>
-      <Text>{fileName}</Text>
+      <Text size="s">{fileName}</Text>
       {hasError && <ErrorText>{errorMessage}</ErrorText>}
     </Wrapper>
   );

--- a/src/renderer/src/components/finish/finish-main-content.tsx
+++ b/src/renderer/src/components/finish/finish-main-content.tsx
@@ -26,7 +26,7 @@ export default function FinishMainContent({
         </Stack>
         <Card>
           <Stack gap={{ base: "4", xl: "8" }}>
-            <styled.h3>{t("finish.subtitle")}</styled.h3>
+            <styled.h2 textStyle="subtitle.md.default">{t("finish.subtitle")}</styled.h2>
             <Grid columns={4} gap="8" justifyContent="center" width="full">
               {children}
             </Grid>

--- a/src/renderer/src/components/spinner/index.tsx
+++ b/src/renderer/src/components/spinner/index.tsx
@@ -11,7 +11,7 @@ const SVG = styled("svg", {
 
 export default function Spinner() {
   return (
-    <SVG width={48} height={48} fill="none" xmlns="http://www.w3.org/2000/svg">
+    <SVG width={48} height={48} viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="M24 42c9.941 0 18-8.059 18-18S33.941 6 24 6 6 14.059 6 24s8.059 18 18 18Z"
         stroke="#E6E8FF"


### PR DESCRIPTION
Se corrigió el renderizado del spinner en la pantalla de finalización del anonimizador y se unificó el estilo del componente `FileCheck` para que sea visualmente consistente con `FilePreview`.

**Cambios:**
- Se agregó `viewBox` al SVG del `Spinner` para que escale correctamente al ser redimensionado por CSS (evitaba el recorte que lo hacía verse "chueco")
- Se igualaron las dimensiones del card de `FileCheck` (150×200) con las de `FilePreview`
- Se aplicó el mismo `textStyle` al subtítulo de la pantalla de finalización que en la pantalla de preview
- Se unificó el tamaño de fuente del nombre de archivo (`size="s"`) en `FileCheck`

## Summary by Sourcery

Align file check UI and loading spinner behavior with the file preview and finish screens for consistent layout and typography.

Bug Fixes:
- Ensure the loading spinner scales correctly by defining an appropriate SVG viewBox to prevent visual clipping.

Enhancements:
- Unify FileCheck card dimensions and max-width with FilePreview for a consistent file tile layout.
- Standardize the file name text size in FileCheck for uniform typography across file tiles.
- Apply the shared subtitle text style on the finish screen to match the preview screen's heading hierarchy.