### PR TITLE
Fix/responsive home layout

### DIFF
--- a/src/renderer/src/components/layout/main-content.tsx
+++ b/src/renderer/src/components/layout/main-content.tsx
@@ -4,6 +4,7 @@ import { stack } from "@/styled/patterns";
 const content = cva({
   base: {
     flex: "1",
+    minH: "0",
 
     width: "full",
     overflowY: "auto",

--- a/src/renderer/src/components/layout/main-content.tsx
+++ b/src/renderer/src/components/layout/main-content.tsx
@@ -6,6 +6,7 @@ const content = cva({
     flex: "1",
 
     width: "full",
+    overflowY: "auto",
 
     bg: "bg.primary",
   },

--- a/src/renderer/src/layout/home.tsx
+++ b/src/renderer/src/layout/home.tsx
@@ -1,6 +1,5 @@
 import BuiltBy from "@/components/brand/built-by";
 import { css } from "@/styled/css";
-import { stack } from "@/styled/patterns";
 
 const background = css({
   display: "flex",
@@ -11,22 +10,27 @@ const background = css({
 
   p: "8",
 });
-const inner = css(
-  stack.raw({ justify: "center", align: "center", gap: "12" }),
-  {
-    pos: "relative",
 
-    bg: "bg.secondary",
-    border: "primary",
+const inner = css({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
 
-    width: "full",
-    height: "full",
-  },
-);
+  bg: "bg.secondary",
+  border: "primary",
 
-const builtBy = css({
-  pos: "absolute",
-  bottom: "16", // 64px
+  width: "full",
+  height: "full",
+
+  overflowY: "auto",
+  p: "8",
+});
+
+const childrenArea = css({
+  flex: "1",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
 });
 
 interface HomeLayoutProps {
@@ -36,12 +40,8 @@ export default function HomeLayout({ children }: HomeLayoutProps) {
   return (
     <main className={background}>
       <div className={inner}>
-        {children}
-
-        {/* Floating content below */}
-        <div className={builtBy}>
-          <BuiltBy />
-        </div>
+        <div className={childrenArea}>{children}</div>
+        <BuiltBy />
       </div>
     </main>
   );

--- a/src/renderer/src/layout/home.tsx
+++ b/src/renderer/src/layout/home.tsx
@@ -25,6 +25,7 @@ const inner = css({
   height: "full",
 
   overflowY: "auto",
+  pb: "8",
 });
 
 const childrenArea = css({

--- a/src/renderer/src/layout/home.tsx
+++ b/src/renderer/src/layout/home.tsx
@@ -16,6 +16,8 @@ const inner = css({
   flexDirection: "column",
   alignItems: "center",
 
+  pos: "relative",
+
   bg: "bg.secondary",
   border: "primary",
 
@@ -23,7 +25,6 @@ const inner = css({
   height: "full",
 
   overflowY: "auto",
-  p: "8",
 });
 
 const childrenArea = css({

--- a/src/renderer/src/routes/home/features.tsx
+++ b/src/renderer/src/routes/home/features.tsx
@@ -1,5 +1,5 @@
-import BuiltBy from "@/components/brand/built-by";
 import FeatureIcon from "@/components/feature-icon";
+import Footer from "@/components/layout/footer";
 import Header from "@/components/layout/header";
 import MainContent from "@/components/layout/main-content";
 import Card from "@/components/ui/card";
@@ -15,13 +15,6 @@ import {
 } from "@tanstack/react-router";
 import type { Icon } from "phosphor-react";
 import { useTranslation } from "react-i18next";
-
-const builtBy = css({
-  pos: "absolute",
-  bottom: "16", // 64px
-  left: "[50%]",
-  transform: "[translateX(-50%)]",
-});
 
 interface CardToolProps extends LinkComponentProps {
   title: string;
@@ -86,11 +79,8 @@ function RouteComponent() {
               />
             </Grid>
           </Stack>
-          {/* Floating content below */}
-          <div className={builtBy}>
-            <BuiltBy />
-          </div>
         </MainContent>
+        <Footer withBuiltBy />
       </Stack>
     </APIProtected>
   );


### PR DESCRIPTION
Se corrigió la superposición entre el componente `BuiltBy` ("Plataforma hecha por datagénero") y el contenido de las pantallas de inicio, visible en monitores de baja resolución.

**Causa:** `BuiltBy` usaba `position: absolute; bottom: 64px`, mientras el contenido principal se centraba en el 100% del contenedor, incluyendo esa zona reservada.

**Cambios:**
- `HomeLayout`: se reemplaza el posicionamiento absoluto por un layout flex en flujo, donde `BuiltBy` siempre queda por debajo del contenido sin solaparse
- features.tsx: se reemplaza el `BuiltBy` absoluto por `<Footer withBuiltBy />`, alineándose con el resto de las rutas de la app
- `MainContent`: se agrega `overflowY: "auto"` para que cualquier pantalla con contenido que exceda la altura disponible scrollee en lugar de desbordar

## Issue relacionado
Issue #79

## Summary by Sourcery

Adjust home layout structure to prevent the BuiltBy branding component from overlapping main content on smaller screens and align its usage with the global layout patterns.

Bug Fixes:
- Ensure the BuiltBy section no longer overlaps home screen content on low-resolution displays by placing it after the main content in the layout flow.
- Allow overflowing home and main content areas to scroll vertically instead of visually overflowing the viewport.

Enhancements:
- Unify the home features route layout with the rest of the app by replacing the ad-hoc BuiltBy positioning with the shared Footer component including BuiltBy.