### PR TITLE
Feat/entity manager mention feedback

### DIFF
--- a/src/renderer/src/components/anonymizer/label-manager/entity-tab.tsx
+++ b/src/renderer/src/components/anonymizer/label-manager/entity-tab.tsx
@@ -132,6 +132,16 @@ const suffixBadge = css({
   letterSpacing: "wide",
 });
 
+const textItemSplitHighlight = {
+  bg: "[#D9DCFF]",
+  boxShadow: "[inset 0 0 0 1px #8A92D8]",
+} as const;
+
+const textItemConfirmingSplitHighlight = {
+  bg: "[#C8CDF8]",
+  boxShadow: "[inset 0 0 0 2px #6F78CE]",
+} as const;
+
 const textItemStyle = css({
   display: "flex",
   alignItems: "flex-start",
@@ -143,16 +153,14 @@ const textItemStyle = css({
   minW: "0",
   w: "full",
   boxSizing: "border-box",
+  "&:hover": textItemSplitHighlight,
 });
 
 const textItemDraggingStyle = css({ opacity: "0.35" });
-const textItemPendingSplitStyle = css({
-  bg: "[#D9DCFF]",
-  boxShadow: "[inset 0 0 0 1px #8A92D8]",
-});
+const textItemPendingSplitStyle = css(textItemSplitHighlight);
 const textItemConfirmingSplitStyle = css({
-  bg: "[#C8CDF8]",
-  boxShadow: "[inset 0 0 0 2px #6F78CE]",
+  ...textItemConfirmingSplitHighlight,
+  "&:hover": textItemConfirmingSplitHighlight,
 });
 
 const textContextMenu = css({
@@ -250,6 +258,7 @@ interface DraggableTextChipProps {
   displayText: string;
   onRemove: () => void;
   onCreateGroup: (position: { x: number; y: number }) => void;
+  canCreateGroup: boolean;
   isSplitTarget: boolean;
   isSplitActionHovered: boolean;
 }
@@ -260,6 +269,7 @@ function DraggableTextChip({
   displayText,
   onRemove,
   onCreateGroup,
+  canCreateGroup,
   isSplitTarget,
   isSplitActionHovered,
 }: DraggableTextChipProps) {
@@ -283,6 +293,7 @@ function DraggableTextChip({
       onContextMenu={(event) => {
         event.preventDefault();
         event.stopPropagation();
+        if (!canCreateGroup) return;
         onCreateGroup({ x: event.clientX, y: event.clientY });
       }}
     >
@@ -689,13 +700,13 @@ export default function LabelEntityTab({
               event.preventDefault();
               event.stopPropagation();
             }}
+            onPointerEnter={() => setTextMenuActionHovered(true)}
+            onPointerLeave={() => setTextMenuActionHovered(false)}
           >
             <button
               type="button"
               className={textContextMenuButton}
               onClick={handleCreateGroupFromText}
-              onMouseEnter={() => setTextMenuActionHovered(true)}
-              onMouseLeave={() => setTextMenuActionHovered(false)}
             >
               <PlusCircle size={14} />
               Crear nuevo grupo
@@ -889,6 +900,9 @@ export default function LabelEntityTab({
                                             group.canonicalId,
                                             normText,
                                           )
+                                        }
+                                        canCreateGroup={
+                                          group.mentions.length > 1
                                         }
                                         onCreateGroup={(position) => {
                                           setTextMenu({

--- a/src/renderer/src/components/anonymizer/label-manager/entity-tab.tsx
+++ b/src/renderer/src/components/anonymizer/label-manager/entity-tab.tsx
@@ -291,9 +291,9 @@ function DraggableTextChip({
           : ""
       }`}
       onContextMenu={(event) => {
+        if (!canCreateGroup) return;
         event.preventDefault();
         event.stopPropagation();
-        if (!canCreateGroup) return;
         onCreateGroup({ x: event.clientX, y: event.clientY });
       }}
     >

--- a/src/renderer/src/components/file-annotator/index.tsx
+++ b/src/renderer/src/components/file-annotator/index.tsx
@@ -116,7 +116,7 @@ export default function FileAnnotator({ file, isAnnotable = false }: Props) {
   const fileRef = useRef<HTMLDivElement>(null);
 
   const [label, setLabel] = useState<AllLabels | null>(null);
-  const [labelManagerOpen, setLabelManagerOpen] = useState(false);
+  const [labelManagerOpen, setLabelManagerOpen] = useState(isAnnotable);
 
   const paragraphs = file.paragraphs ?? [];
   const { tags, words } = useExcludedTagsConfig();


### PR DESCRIPTION
Este PR mejora la experiencia de uso del gestor de entidades. Las menciones individuales ahora muestran feedback visual al pasar el cursor, anticipando que pueden interactuarse, mientras que la acción de crear un nuevo grupo queda deshabilitada cuando no tiene sentido dividir un grupo de una sola mención.

Además, el gestor de entidades se muestra abierto por defecto en el flujo de anonimización para facilitar la revisión y edición desde el inicio.

## Summary by Sourcery

Improve the entity manager UX by adding clearer interaction feedback on mentions and adjusting its default visibility in the anonymization flow.

New Features:
- Highlight entity mentions on hover to indicate they are interactive within the entity manager.
- Disable creating a new group from context when the current group has only a single mention.
- Open the entity manager by default when a file is annotable in the anonymization flow.