### PR TITLE
Fix/invalid entity offsets

### DIFF
--- a/src/renderer/src/hooks/usePredict.ts
+++ b/src/renderer/src/hooks/usePredict.ts
@@ -90,10 +90,17 @@ export function usePredict(
             if (workflow === "anonymizer") {
               const stored = await getStoredValidation(paragraph, controller);
               if (stored !== null) {
+                console.debug(
+                  `[predict] Restored ${stored.length} labels from DB validation`,
+                  { paragraphId: paragraph.id.slice(0, 60) },
+                );
                 fromValidationRef.current.add(paragraph.id);
                 dispatch(addPredictions(file.data.name, stored));
                 return stored;
               }
+              console.debug("[predict] No stored validation — running model predict", {
+                paragraphId: paragraph.id.slice(0, 60),
+              });
             }
             const predictions = await predict(paragraph, controller, workflow);
             dispatch(addPredictions(file.data.name, predictions));

--- a/src/renderer/src/services/aymurai/__tests__/validation.test.ts
+++ b/src/renderer/src/services/aymurai/__tests__/validation.test.ts
@@ -1,5 +1,53 @@
-import { describe, expect, it } from "vitest";
-import { normalizeValidationLabel } from "../validation";
+import { describe, expect, it, vi } from "vitest";
+import getStoredValidation, {
+  normalizeValidationLabel,
+} from "../validation";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function makeController() {
+  return new AbortController();
+}
+
+function makeParagraph(value: string) {
+  return {
+    id: value,
+    value,
+    document_id: "doc-1",
+  };
+}
+
+function makeRawLabel(
+  overrides: Partial<{
+    text: string;
+    start_char: number;
+    end_char: number;
+    aymurai_anonymize: boolean | null;
+    aymurai_alt_text: string | null;
+    aymurai_alt_start_char: number | null;
+    aymurai_alt_end_char: number | null;
+    canonical_entity_id: string | null;
+  }> = {},
+) {
+  return {
+    text: overrides.text ?? "Juan",
+    start_char: overrides.start_char ?? 4,
+    end_char: overrides.end_char ?? 8,
+    attrs: {
+      aymurai_label: "PERSONA",
+      aymurai_label_subclass: null,
+      aymurai_alt_text: overrides.aymurai_alt_text ?? null,
+      aymurai_alt_start_char: overrides.aymurai_alt_start_char ?? null,
+      aymurai_alt_end_char: overrides.aymurai_alt_end_char ?? null,
+      aymurai_anonymize: overrides.aymurai_anonymize ?? true,
+      canonical_entity_id: overrides.canonical_entity_id ?? "canon-1",
+      aymurai_label_instance: null,
+      aymurai_disambiguation: null,
+    },
+  };
+}
 
 describe("normalizeValidationLabel", () => {
   const base = {
@@ -90,5 +138,88 @@ describe("normalizeValidationLabel", () => {
     const result = normalizeValidationLabel(base, "para-1");
     expect(result.attrs.aymurai_disambiguation).toBeNull();
     expect(result.attrs.aymurai_label_instance).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getStoredValidation — offset integrity guard
+// ---------------------------------------------------------------------------
+
+vi.mock("@/services/api", () => ({
+  default: {
+    post: vi.fn(),
+    defaults: { baseURL: "http://localhost" },
+  },
+}));
+
+describe("getStoredValidation — offset integrity guard", () => {
+  // The paragraph text is "Sr. Juan fue aquí" (18 chars).
+  // "Juan" sits at [4, 8].
+  const PARA_TEXT = "Sr. Juan fue aquí";
+  const paragraph = makeParagraph(PARA_TEXT);
+
+  async function setupApiResponse(labels: ReturnType<typeof makeRawLabel>[]) {
+    const { default: api } = await import("@/services/api");
+    vi.mocked(api.post).mockResolvedValueOnce({ data: labels });
+  }
+
+  it("returns normalized labels when all active offsets match paragraph text", async () => {
+    await setupApiResponse([makeRawLabel()]);
+
+    const result = await getStoredValidation(paragraph, makeController());
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0].text).toBe("Juan");
+    expect(result![0].start_char).toBe(4);
+    expect(result![0].end_char).toBe(8);
+  });
+
+  it("returns null when an active label has a text mismatch (PDF drift scenario)", async () => {
+    // offset [4,8] would slice "Juan" from the original text, but the stored
+    // label says "Jüan" — simulates the backend having a slightly different PDF
+    // extraction that caused the stored text to drift.
+    await setupApiResponse([makeRawLabel({ text: "Jüan" })]);
+
+    const result = await getStoredValidation(paragraph, makeController());
+    expect(result).toBeNull();
+  });
+
+  it("returns null when an active label has out-of-bounds end_char", async () => {
+    await setupApiResponse([
+      makeRawLabel({ end_char: PARA_TEXT.length + 5 }),
+    ]);
+    const result = await getStoredValidation(paragraph, makeController());
+    expect(result).toBeNull();
+  });
+
+  it("returns null when an active label has start_char >= end_char", async () => {
+    await setupApiResponse([makeRawLabel({ start_char: 8, end_char: 4 })]);
+    const result = await getStoredValidation(paragraph, makeController());
+    expect(result).toBeNull();
+  });
+
+  it("does NOT apply the offset check to excluded labels (aymurai_anonymize: false)", async () => {
+    // An excluded label whose text slice would not match — but since it's
+    // excluded it should not block the stored validation from being returned.
+    await setupApiResponse([
+      makeRawLabel({ aymurai_anonymize: false, text: "ghost" }),
+    ]);
+    const result = await getStoredValidation(paragraph, makeController());
+    // No active labels → every() vacuously true → return the labels
+    expect(result).not.toBeNull();
+  });
+
+  it("returns [] when the backend returns an empty array (no entities stored)", async () => {
+    await setupApiResponse([]);
+    const result = await getStoredValidation(paragraph, makeController());
+    expect(result).toEqual([]);
+  });
+
+  it("returns null on network error (graceful fallback)", async () => {
+    const { default: api } = await import("@/services/api");
+    vi.mocked(api.post).mockRejectedValueOnce(new Error("Network error"));
+
+    const result = await getStoredValidation(paragraph, makeController());
+    expect(result).toBeNull();
   });
 });

--- a/src/renderer/src/services/aymurai/predict.ts
+++ b/src/renderer/src/services/aymurai/predict.ts
@@ -34,17 +34,23 @@ export default async function predict(
     );
     const parsed = predictSchema.parse(response.data);
 
-    const data = parsed.labels.map(
-      (l) =>
-        ({
-          ...l,
-          mentionId: crypto.randomUUID(),
-          start_char: l.attrs.aymurai_alt_start_char || l.start_char,
-          end_char: l.attrs.aymurai_alt_end_char || l.end_char,
-          text: l.attrs.aymurai_alt_text || l.text,
-          paragraphId: paragraph.id,
-        }) as PredictLabel,
-    );
+    const data = parsed.labels.map((l) => {
+      const altStart = l.attrs.aymurai_alt_start_char;
+      const altEnd = l.attrs.aymurai_alt_end_char;
+      // Only apply alt offsets when both are present and form a valid range.
+      // The NER pipeline can emit inverted alt offsets (altStart > altEnd) for
+      // non-alphanumeric entities like "∙" — using them would produce an
+      // invalid_range error at export time.
+      const useAlt = altStart !== null && altEnd !== null && altStart < altEnd;
+      return {
+        ...l,
+        mentionId: crypto.randomUUID(),
+        start_char: useAlt ? altStart : l.start_char,
+        end_char: useAlt ? altEnd : l.end_char,
+        text: useAlt && l.attrs.aymurai_alt_text ? l.attrs.aymurai_alt_text : l.text,
+        paragraphId: paragraph.id,
+      } as PredictLabel;
+    });
 
     return data;
   } catch (e) {

--- a/src/renderer/src/services/aymurai/predict.ts
+++ b/src/renderer/src/services/aymurai/predict.ts
@@ -41,7 +41,7 @@ export default async function predict(
       // The NER pipeline can emit inverted alt offsets (altStart > altEnd) for
       // non-alphanumeric entities like "∙" — using them would produce an
       // invalid_range error at export time.
-      const useAlt = altStart !== null && altEnd !== null && altStart < altEnd;
+      const useAlt = altStart != null && altEnd != null && altStart < altEnd;
       return {
         ...l,
         mentionId: crypto.randomUUID(),

--- a/src/renderer/src/services/aymurai/queries.ts
+++ b/src/renderer/src/services/aymurai/queries.ts
@@ -180,9 +180,12 @@ export const disambiguate = (file: DocFile) =>
         }
 
         return item.labels.map((l) => {
-          const resolvedText = l.attrs.aymurai_alt_text ?? l.text;
-          const resolvedStart = l.attrs.aymurai_alt_start_char ?? l.start_char;
-          const resolvedEnd = l.attrs.aymurai_alt_end_char ?? l.end_char;
+          const altStart = l.attrs.aymurai_alt_start_char;
+          const altEnd = l.attrs.aymurai_alt_end_char;
+          const useAlt = altStart !== null && altEnd !== null && altStart < altEnd;
+          const resolvedText = useAlt && l.attrs.aymurai_alt_text ? l.attrs.aymurai_alt_text : l.text;
+          const resolvedStart = useAlt ? altStart : l.start_char;
+          const resolvedEnd = useAlt ? altEnd : l.end_char;
 
           // Prefer original mentionId so downstream D&D state stays stable.
           const orig = origByPos.get(`${l.start_char}:${l.end_char}`);

--- a/src/renderer/src/services/aymurai/validation.ts
+++ b/src/renderer/src/services/aymurai/validation.ts
@@ -69,7 +69,31 @@ export default async function getStoredValidation(
     // - []           → paragraph validated with no entities
     // - [...]        → restore stored annotations
     const labels = validationResponseSchema.parse(response.data);
-    return labels.map((l) => normalizeValidationLabel(l, paragraph.id));
+    const normalized = labels.map((l) => normalizeValidationLabel(l, paragraph.id));
+
+    // Defensive: validate that stored offsets are still consistent with the
+    // current paragraph text.
+    const active = normalized.filter((l) => l.attrs.aymurai_anonymize !== false);
+    const isValid = active.every(
+      (l) =>
+        Number.isFinite(l.start_char) &&
+      Number.isFinite(l.end_char) &&
+      l.start_char >= 0 &&
+      l.end_char <= paragraph.value.length &&
+      l.start_char < l.end_char &&
+      paragraph.value.slice(l.start_char, l.end_char) === l.text,
+    );
+    // If any active label fails basic offset checks, discard the stored data
+    // and fall back to fresh model predict + disambiguation.
+    if (!isValid) {
+      console.warn(
+        "[validation] Stored offsets do not match paragraph text — falling back to predict.",
+        { paragraphId: paragraph.id },
+      );
+      return null;
+    }
+
+    return normalized;
   } catch (e) {
     // Propagate request cancellations so React Query can clean up properly
     if (e instanceof CanceledError) throw e;

--- a/src/renderer/src/services/aymurai/validation.ts
+++ b/src/renderer/src/services/aymurai/validation.ts
@@ -77,11 +77,11 @@ export default async function getStoredValidation(
     const isValid = active.every(
       (l) =>
         Number.isFinite(l.start_char) &&
-      Number.isFinite(l.end_char) &&
-      l.start_char >= 0 &&
-      l.end_char <= paragraph.value.length &&
-      l.start_char < l.end_char &&
-      paragraph.value.slice(l.start_char, l.end_char) === l.text,
+        Number.isFinite(l.end_char) &&
+        l.start_char >= 0 &&
+        l.end_char <= paragraph.value.length &&
+        l.start_char < l.end_char &&
+        paragraph.value.slice(l.start_char, l.end_char) === l.text,
     );
     // If any active label fails basic offset checks, discard the stored data
     // and fall back to fresh model predict + disambiguation.

--- a/src/renderer/src/utils/anonymizer/export-validation.ts
+++ b/src/renderer/src/utils/anonymizer/export-validation.ts
@@ -258,9 +258,28 @@ export function assertValidAnonymizerExportState(
   const issues = validateAnonymizerExportState(file, labels);
   if (issues.length === 0) return;
 
+  // Group issues by code so a quick console.table() is readable.
+  const byCode = issues.reduce<Record<string, number>>((acc, i) => {
+    acc[i.code] = (acc[i.code] ?? 0) + 1;
+    return acc;
+  }, {});
   console.error("Invalid anonymizer export annotations", {
     fileName: file.data.name,
+    issueSummary: byCode,
     issues,
   });
+  console.table(
+    issues.map((i) => ({
+      code: i.code,
+      paragraphId:
+        i.entity.paragraphId.length > 40
+          ? `${i.entity.paragraphId.slice(0, 40)}…`
+          : i.entity.paragraphId,
+      label: i.entity.label,
+      start: i.entity.start,
+      end: i.entity.end,
+      text: i.entity.text,
+    })),
+  );
   throw new AnonymizerExportValidationError(issues);
 }


### PR DESCRIPTION
El pipeline NER del backend puede emitir entidades no alfanuméricos (ej. "∙") con `aymurai_alt_start_char > aymurai_alt_end_char`. El frontend los aplicaba sin validar, generando predicciones con `start_char >= end_char` que bloqueaban la exportación con `invalid_range`.

**Cambios:**
- `predict.ts` / `queries.ts`: los alt offsets solo se aplican si `altStart < altEnd`; en caso contrario se usan las posiciones originales del NER
- `validation.ts`: las anotaciones almacenadas en backend se descartan si alguna posición no coincide con el texto del párrafo actual (caída defensiva al modelo)
- `export-validation.ts` / `usePredict.ts`: mejoras de logging para facilitar el diagnóstico

Cierra #73.

## Summary by Sourcery

Validate and sanitize entity offsets from NER/validation data to prevent invalid ranges from breaking anonymizer export, and improve diagnostics around stored validations and export failures.

Bug Fixes:
- Ignore invalid alternative NER offsets and fall back to original positions to avoid generating entities with start_char >= end_char.
- Discard stored validation labels whose active offsets no longer match the current paragraph text to prevent corrupt annotations from blocking export.

Enhancements:
- Add detailed logging for prediction/validation workflows and anonymizer export issues, including grouped issue summaries and tabular output for easier debugging.

Tests:
- Extend validation tests to cover stored validation offset integrity checks, including drifted text, out-of-bounds ranges, inverted ranges, excluded labels, empty responses, and network errors.