### PR TITLE
fix(useFileParse): use position-based paragraph ID to avoid key collisions

### DIFF
--- a/src/renderer/src/hooks/useFileParse.ts
+++ b/src/renderer/src/hooks/useFileParse.ts
@@ -23,18 +23,18 @@ export function useFileParse(
   });
 
   useEffect(() => {
-    queries.forEach((query, i) => {
-      const file = files[i];
+    queries.forEach((query, fileIndex) => {
+      const file = files[fileIndex];
       // Use the Redux state as the guard: if paragraphs are already set, skip.
       // This correctly re-dispatches when the same file is reloaded after a replace.
       if (!query.isSuccess || !query.data || file.paragraphs !== undefined)
         return;
       dispatch(
         addParagraphs(
-          query.data.document.map((p, i) => ({
+          query.data.document.map((p, paragraphIndex) => ({
             value: p,
             document_id: query.data.document_id,
-            id: `${query.data.document_id}:${i}`,
+            id: `${query.data.document_id}:${paragraphIndex}`,
           })),
           file.data.name,
         ),

--- a/src/renderer/src/hooks/useFileParse.ts
+++ b/src/renderer/src/hooks/useFileParse.ts
@@ -31,10 +31,10 @@ export function useFileParse(
         return;
       dispatch(
         addParagraphs(
-          query.data.document.map((p) => ({
+          query.data.document.map((p, i) => ({
             value: p,
             document_id: query.data.document_id,
-            id: p,
+            id: `${query.data.document_id}:${i}`,
           })),
           file.data.name,
         ),


### PR DESCRIPTION
Al parsear un documento, el `id` de cada párrafo se asignaba con el texto del párrafo mismo. En documentos con párrafos repetidos esto generaba IDs duplicados, causando colisiones de keys en React, compartición incorrecta del query cache de predicciones, y rangos duplicados/superpuestos al exportar.

Se reemplaza `id: p` por `id: \`${document_id}:${i}\`` para que cada párrafo tenga un identificador estable y único basado en su posición en el documento.

## Summary by Sourcery

Bug Fixes:
- Prevent React key collisions, cache sharing issues, and overlapping paragraph ranges by using a document-position-based paragraph ID instead of the paragraph text.