### PR TITLE
fix(disambiguate): mapeo por contenido en lugar de índice de array (#78)

### DIFF
--- a/src/renderer/src/services/aymurai/queries.ts
+++ b/src/renderer/src/services/aymurai/queries.ts
@@ -167,15 +167,33 @@ export const disambiguate = (file: DocFile) =>
 
       const parsed = disambiguateSchema.parse(response.data);
 
-      // Map response items back to paragraphs by **index** — the backend
-      // echoes the array in the same order we sent it.
-      return parsed.data.flatMap((item, i) => {
-        const paragraph = paragraphs[i];
+      // Build a consumption queue per paragraph text so we can match response
+      // items by content instead of array index. This tolerates backend
+      // reordering and count drops. Duplicate paragraph texts are matched in
+      // the order they appear in the original paragraphs array.
+      const paragraphQueue = new Map<string, Paragraph[]>();
+      for (const p of paragraphs) {
+        const q = paragraphQueue.get(p.value) ?? [];
+        q.push(p);
+        paragraphQueue.set(p.value, q);
+      }
+      const consumed = new Map<string, number>();
+      const matchedParagraphIds = new Set<string>();
+
+      const disambiguated = parsed.data.flatMap((item) => {
+        const queue = paragraphQueue.get(item.document) ?? [];
+        const nextIdx = consumed.get(item.document) ?? 0;
+        const paragraph = queue[nextIdx];
+        consumed.set(item.document, nextIdx + 1);
+
+        if (!paragraph) return [];
+
+        matchedParagraphIds.add(paragraph.id);
 
         // Build a lookup from (start_char, end_char) → original mention so we
         // can reuse the stable mentionId.
         const origByPos = new Map<string, PredictLabel>();
-        for (const orig of byParagraphId.get(paragraph?.id ?? "") ?? []) {
+        for (const orig of byParagraphId.get(paragraph.id) ?? []) {
           origByPos.set(`${orig.start_char}:${orig.end_char}`, orig);
         }
 
@@ -207,10 +225,18 @@ export const disambiguate = (file: DocFile) =>
               aymurai_label_instance: l.attrs.aymurai_label_instance ?? null,
               aymurai_disambiguation: l.attrs.aymurai_disambiguation ?? null,
             },
-            paragraphId: paragraph?.id ?? item.document,
+            paragraphId: paragraph.id,
           } satisfies PredictLabel;
         });
       });
+
+      // Preserve raw predictions for any paragraph the backend did not return,
+      // so a backend count drop never silently erases annotations.
+      const unmatched = predictions.filter(
+        (p) => !matchedParagraphIds.has(p.paragraphId),
+      );
+
+      return [...disambiguated, ...unmatched];
     },
   });
 


### PR DESCRIPTION
El endpoint `/anonymizer/disambiguate` devuelve un array de párrafos procesados. El código anterior asumía que el backend respondía en el mismo orden y con la misma cantidad de elementos que el request, mapeando por índice. Si el backend reordenaba o descartaba algún párrafo, las etiquetas quedaban asignadas al párrafo incorrecto, o el `paragraphId` se seteaba con el texto plano del párrafo (que tras el fix del PR #85 ya no coincide con ningún ID en el store de Redux).

**Cambios:**
- Se reemplaza el `flatMap((item, i) => paragraphs[i])` por una *consumption queue* keyed por texto: cada item del response se resuelve buscando el primer párrafo no consumido con ese texto, tolerando reordenamiento y párrafos duplicados.
- Si el backend omite un párrafo, sus predicciones originales se preservan en lugar de descartarse silenciosamente.

Resuelve parcialmente #78.

## Summary by Sourcery

Align disambiguation results with their original paragraphs based on paragraph content instead of response index, and preserve predictions for paragraphs omitted by the backend.

Bug Fixes:
- Match disambiguation response items to paragraphs by their text content, tolerating backend reordering and duplicate paragraphs to avoid misassigned labels and invalid paragraph IDs.
- Keep existing predictions for paragraphs that the backend omits from the disambiguation response so annotations are not silently lost.