### PR TITLE
fix(useLocal): depuración de localStorage — groupOrder y categoryAssignments (#78)

### DIFF
--- a/src/renderer/src/store/useLocal.ts
+++ b/src/renderer/src/store/useLocal.ts
@@ -19,8 +19,6 @@ interface LocalStorageStore {
   setExcludedWords: (words: string[]) => void;
   groupOrder: Record<string, string[]> | null;
   setGroupOrder: (order: Record<string, string[]>) => void;
-  categoryAssignments: Record<string, string> | null;
-  setCategoryAssignments: (assignments: Record<string, string>) => void;
 }
 
 const useLocalStore = create<LocalStorageStore>()(
@@ -46,11 +44,17 @@ const useLocalStore = create<LocalStorageStore>()(
         setExcludedWords: (words) => set({ excludedWords: words }),
         groupOrder: null,
         setGroupOrder: (groupOrder) => set({ groupOrder }),
-        categoryAssignments: null,
-        setCategoryAssignments: (categoryAssignments) => set({ categoryAssignments }),
       }),
       {
         name: "local-storage",
+        // groupOrder holds canonical UUIDs regenerated each session, so
+        // persisting it would only accumulate stale data across sessions.
+        partialize: (state) => ({
+          serverHost: state.serverHost,
+          tutorialsSeen: state.tutorialsSeen,
+          excludedTags: state.excludedTags,
+          excludedWords: state.excludedWords,
+        }),
       },
     ),
   ),
@@ -85,10 +89,8 @@ export const useExcludedTagsConfigActions = () =>
 export const useGroupOrder = () =>
   useLocalStore(useShallow((s) => ({
     groupOrder: s.groupOrder,
-    categoryAssignments: s.categoryAssignments,
   })));
 export const useGroupOrderActions = () =>
   useLocalStore(useShallow((s) => ({
     setGroupOrder: s.setGroupOrder,
-    setCategoryAssignments: s.setCategoryAssignments,
   })));


### PR DESCRIPTION
El store de Zustand persistía en `localStorage` dos campos que acumulaban datos indefinidamente entre sesiones:

- `groupOrder` almacena el orden de drag-and-drop del label manager como `Record<category, canonicalId[]>`. Los `canonicalId` son UUIDs generados frescos cada vez que se procesan archivos, por lo que cualquier entrada de una sesión anterior es basura garantizada. Se excluye de la persistencia via `partialize`; sigue funcionando en RAM durante la sesión.
- `categoryAssignments` era dead code: `setCategoryAssignments` nunca fue invocado en ningún call site. Se elimina completamente del store y sus hooks.

**Cambios:**
- Se agrega `partialize` al config de `persist` para serializar solo `serverHost`, `tutorialsSeen`, `excludedTags` y `excludedWords`.
- Se elimina `categoryAssignments` / `setCategoryAssignments` del tipo, la implementación y los hooks exportados.

Cierra #78.

## Summary by Sourcery

Restrict persisted Zustand local storage state to stable configuration fields and remove unused category assignment state from the local store and related hooks.

Bug Fixes:
- Stop persisting transient drag-and-drop group order data that becomes stale across sessions.

Enhancements:
- Add a persist configuration partializer so only relevant configuration fields are stored in localStorage.
- Remove dead categoryAssignments state and its setters from the local store and hooks.