### PR TITLE
fix: migrate pnpm allowBuilds to v11 and pin packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "aymurai",
   "version": "1.5.0",
   "private": true,
+  "packageManager": "pnpm@11.18.0",
   "main": "./out/main/index.js",
   "scripts": {
     "dev:web": "cross-env VITE_APP_MODE=web vite --config vite.config.ts",
@@ -98,8 +99,5 @@
     "wait-on": "^6.0.1",
     "zod": "^4.4.3",
     "zustand": "^5.0.14"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["electron", "esbuild"]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,11 @@
 # `pnpm <script>` pre-run dep-checks succeed for this Electron toolchain.
 blockExoticSubdeps: false
 allowBuilds:
-  '@aymurai/ui': true
-  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/1bbbdf739418ce550344a4ca863074d1c53be389': true
+  # github: shorthand deps resolve through codeload tarball URLs, not git
+  # protocol URLs, so pnpm's repo-URL allowBuilds form (11.11.0+) doesn't
+  # match them — the exact commit hash below must be bumped by hand whenever
+  # @aymurai/ui's pinned tag changes (see package.json).
+  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/93821cce3a0d82198d5acdf5c33cc1d2804cdbec': true
   '@biomejs/biome': true
   agent-browser: false
   electron: true


### PR DESCRIPTION
## Summary
- `pnpm-workspace.yaml` still had the v10-shaped `allowBuilds` entry for `@aymurai/ui`, which broke `pnpm install` under pnpm 11 (`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` on the git-hosted build script) and pointed at a stale commit hash from before the v0.5.0 bump in #90.
- Updated the entry to the commit hash pnpm 11 currently resolves, with a comment on why it must be bumped by hand on future `@aymurai/ui` tag changes (pnpm's repo-URL `allowBuilds` form doesn't match `github:` shorthand deps, which resolve via codeload tarball URLs).
- Dropped the now-dead `"pnpm": { "onlyBuiltDependencies": [...] }` field from `package.json` (pnpm 11 no longer reads it, was just producing a warning on every install).
- Pinned `"packageManager": "pnpm@11.18.0"` so everyone installs with the same pnpm version regardless of what's cached locally.

Split out from `feature/document-summary` since it's unrelated tooling.

## Test plan
- [x] `pnpm install` succeeds clean on pnpm 11.18.0
- [x] Pre-commit (biome) and pre-push (knip, typecheck) hooks pass

## Summary by Sourcery

Update pnpm workspace configuration and project metadata to align with pnpm 11 and ensure consistent installs.

Build:
- Update pnpm-workspace allowBuilds entry for @aymurai/ui to the current commit hash used by pnpm 11 and document the need for manual bumps on future tag changes.
- Remove the deprecated pnpm.onlyBuiltDependencies configuration from package.json that is no longer honored by pnpm 11.
- Pin the project packageManager to pnpm@11.18.0 to standardize the pnpm version used across all developers.