### PR TITLE
Split identified speakers from suggested roles in the Voz a Texto side panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@aymurai/ui": "github:AymurAI/ui-components#0ea4007e50475c216d4240a26a4915571f8c9ef4",
+    "@aymurai/ui": "github:AymurAI/ui-components#v0.6.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@aymurai/ui": "github:AymurAI/ui-components#v0.5.0",
+    "@aymurai/ui": "github:AymurAI/ui-components#0ea4007e50475c216d4240a26a4915571f8c9ef4",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -101,11 +101,15 @@ export default defineConfig({
     extend: {
       semanticTokens: {
         colors: {
-          // Superficie oscura de la barra flotante de selección del editor de
-          // Voz a Texto. No está en el preset porque es el único elemento
-          // sobre fondo oscuro de la app.
-          "bg.overlay-dark": { value: "#26244A" },
-          "text.on-overlay-dark": { value: "#FFFFFF" },
+          bg: {
+            // Superficie oscura de la barra flotante de selección del editor
+            // de Voz a Texto. No está en el preset porque es el único
+            // elemento sobre fondo oscuro de la app.
+            "overlay-dark": { value: "#26244A" },
+          },
+          text: {
+            "on-overlay-dark": { value: "#FFFFFF" },
+          },
         },
       },
     },

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -102,9 +102,9 @@ export default defineConfig({
       semanticTokens: {
         colors: {
           bg: {
-            // Superficie oscura de la barra flotante de selección del editor
-            // de Voz a Texto. No está en el preset porque es el único
-            // elemento sobre fondo oscuro de la app.
+            // Dark surface for the Voz a Texto editor's floating selection
+            // toolbar. Not in the preset because it's the only dark-surface
+            // element in the app.
             "overlay-dark": { value: "#26244A" },
           },
           text: {

--- a/panda.config.ts
+++ b/panda.config.ts
@@ -96,6 +96,21 @@ export default defineConfig({
   // Global styles (migrated from Stitches globalStyles.ts)
   globalCss,
 
+  // Theme extensions
+  theme: {
+    extend: {
+      semanticTokens: {
+        colors: {
+          // Superficie oscura de la barra flotante de selección del editor de
+          // Voz a Texto. No está en el preset porque es el único elemento
+          // sobre fondo oscuro de la app.
+          "bg.overlay-dark": { value: "#26244A" },
+          "text.on-overlay-dark": { value: "#FFFFFF" },
+        },
+      },
+    },
+  },
+
   // Other configuration
   strictTokens: true,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@aymurai/ui':
-        specifier: github:AymurAI/ui-components#0ea4007e50475c216d4240a26a4915571f8c9ef4
-        version: https://codeload.github.com/AymurAI/ui-components/tar.gz/0ea4007e50475c216d4240a26a4915571f8c9ef4(@floating-ui/dom@1.7.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: github:AymurAI/ui-components#v0.6.0
+        version: https://codeload.github.com/AymurAI/ui-components/tar.gz/5125acfc2b2de1ff996cbf46d6eaefb08cc0204c(@floating-ui/dom@1.7.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -210,8 +210,8 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/0ea4007e50475c216d4240a26a4915571f8c9ef4':
-    resolution: {gitHosted: true, integrity: sha512-U5GDvzW1CbG94rsvWZuYk+FQnl2suE7Kzp7DKqm69dltEGNQ6F+hxgF0nPMgoIC+2fnrLKxOOPf5OUK0bcwlXA==, tarball: https://codeload.github.com/AymurAI/ui-components/tar.gz/0ea4007e50475c216d4240a26a4915571f8c9ef4}
+  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/5125acfc2b2de1ff996cbf46d6eaefb08cc0204c':
+    resolution: {gitHosted: true, integrity: sha512-2e2OLYoZZZ1MkhkbwXAiNjzNv/UenekwHKOc4qobQJep3pE9AtNOu4QmVEcK+/o40BhOt+e7xpbl0YW8onZmcw==, tarball: https://codeload.github.com/AymurAI/ui-components/tar.gz/5125acfc2b2de1ff996cbf46d6eaefb08cc0204c}
     version: 0.6.0
     peerDependencies:
       react: ^18 || ^19
@@ -6091,7 +6091,7 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/0ea4007e50475c216d4240a26a4915571f8c9ef4(@floating-ui/dom@1.7.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/5125acfc2b2de1ff996cbf46d6eaefb08cc0204c(@floating-ui/dom@1.7.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@phosphor-icons/react': 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-context-menu': 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@aymurai/ui':
-        specifier: github:AymurAI/ui-components#v0.5.0
-        version: https://codeload.github.com/AymurAI/ui-components/tar.gz/93821cce3a0d82198d5acdf5c33cc1d2804cdbec(@floating-ui/dom@1.7.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: github:AymurAI/ui-components#0ea4007e50475c216d4240a26a4915571f8c9ef4
+        version: https://codeload.github.com/AymurAI/ui-components/tar.gz/0ea4007e50475c216d4240a26a4915571f8c9ef4(@floating-ui/dom@1.7.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -22,16 +22,16 @@ importers:
         version: 3.2.2(react@19.2.7)
       '@electron-toolkit/preload':
         specifier: ^3.0.2
-        version: 3.0.2(electron@42.6.0)
+        version: 3.0.2(electron@42.6.0(supports-color@5.5.0))
       '@electron-toolkit/utils':
         specifier: ^4.0.0
-        version: 4.0.0(electron@42.6.0)
+        version: 4.0.0(electron@42.6.0(supports-color@5.5.0))
       '@microsoft/fetch-event-source':
         specifier: ^2.0.1
         version: 2.0.1
       electron-squirrel-startup:
         specifier: ^1.0.1
-        version: 1.0.1
+        version: 1.0.1(supports-color@5.5.0)
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -41,25 +41,25 @@ importers:
         version: 1.9.4
       '@electron-forge/cli':
         specifier: ^6.4.2
-        version: 6.4.2(encoding@0.1.13)
+        version: 6.4.2(bluebird@3.7.2)(encoding@0.1.13)(supports-color@5.5.0)
       '@electron-forge/maker-deb':
         specifier: ^6.4.2
-        version: 6.4.2
+        version: 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
       '@electron-forge/maker-rpm':
         specifier: ^6.4.2
-        version: 6.4.2
+        version: 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
       '@electron-forge/maker-squirrel':
         specifier: ^6.4.2
-        version: 6.4.2
+        version: 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
       '@electron-forge/maker-zip':
         specifier: ^6.4.2
-        version: 6.4.2
+        version: 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
       '@electron-toolkit/tsconfig':
         specifier: ^1.0.1
         version: 1.0.1(@types/node@20.19.43)
       '@pandacss/dev':
         specifier: ^1.11.3
-        version: 1.11.4(jsdom@25.0.1)(typescript@5.9.3)
+        version: 1.11.4(jsdom@25.0.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@pandacss/preset-panda':
         specifier: ^1.11.4
         version: 1.11.4
@@ -86,7 +86,7 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.14)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-plugin':
         specifier: ^1.168.18
-        version: 1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.25.12)(rollup@4.53.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))
+        version: 1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.25.12)(rollup@4.53.3)(supports-color@5.5.0)(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -107,10 +107,10 @@ importers:
         version: 3.4.1
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))
+        version: 4.7.0(supports-color@5.5.0)(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))
       axios:
         specifier: ^1.17.0
-        version: 1.18.1
+        version: 1.18.1(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)
       concurrently:
         specifier: ^7.6.0
         version: 7.6.0
@@ -119,19 +119,19 @@ importers:
         version: 7.0.3
       electron:
         specifier: ^42.3.3
-        version: 42.6.0
+        version: 42.6.0(supports-color@5.5.0)
       electron-builder:
         specifier: ^26.0.12
-        version: 26.0.12(electron-builder-squirrel-windows@26.0.12)
+        version: 26.0.12(bluebird@3.7.2)(electron-builder-squirrel-windows@26.0.12)(supports-color@5.5.0)
       electron-debug:
         specifier: ^3.2.0
-        version: 3.2.0
+        version: 3.2.0(supports-color@5.5.0)
       electron-devtools-installer:
         specifier: ^3.2.1
         version: 3.2.1
       electron-vite:
         specifier: ^5.0.0
-        version: 5.0.0(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))
+        version: 5.0.0(supports-color@5.5.0)(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))
       exceljs:
         specifier: ^4.4.0
         version: 4.4.0
@@ -143,7 +143,7 @@ importers:
         version: 25.10.10(typescript@5.9.3)
       jsdom:
         specifier: ^25.0.1
-        version: 25.0.1
+        version: 25.0.1(supports-color@5.5.0)
       knip:
         specifier: ^6.16.1
         version: 6.24.0
@@ -152,7 +152,7 @@ importers:
         version: 2.1.6
       lint-staged:
         specifier: ^13.3.0
-        version: 13.3.0
+        version: 13.3.0(supports-color@5.5.0)
       markdownlint-cli:
         specifier: ^0.32.2
         version: 0.32.2
@@ -188,10 +188,10 @@ importers:
         version: 6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.9(@types/node@20.19.43)(jsdom@25.0.1)(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))
+        version: 4.1.9(@types/node@20.19.43)(jsdom@25.0.1(supports-color@5.5.0))(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))
       wait-on:
         specifier: ^6.0.1
-        version: 6.0.1
+        version: 6.0.1(debug@4.4.3(supports-color@5.5.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -210,9 +210,9 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/93821cce3a0d82198d5acdf5c33cc1d2804cdbec':
-    resolution: {tarball: https://codeload.github.com/AymurAI/ui-components/tar.gz/93821cce3a0d82198d5acdf5c33cc1d2804cdbec}
-    version: 0.5.0
+  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/0ea4007e50475c216d4240a26a4915571f8c9ef4':
+    resolution: {gitHosted: true, integrity: sha512-U5GDvzW1CbG94rsvWZuYk+FQnl2suE7Kzp7DKqm69dltEGNQ6F+hxgF0nPMgoIC+2fnrLKxOOPf5OUK0bcwlXA==, tarball: https://codeload.github.com/AymurAI/ui-components/tar.gz/0ea4007e50475c216d4240a26a4915571f8c9ef4}
+    version: 0.6.0
     peerDependencies:
       react: ^18 || ^19
       react-dom: ^18 || ^19
@@ -332,24 +332,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.9.4':
     resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.9.4':
     resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.9.4':
     resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.9.4':
     resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
@@ -542,7 +546,7 @@ packages:
     engines: {node: '>=22.12.0'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -1064,48 +1068,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.137.0':
     resolution: {integrity: sha512-EGJ+Bs8iXx8KBH8DQ5BLoEm5lnHaYjlh4/8j8vFhrr/6z4tqONy5BZDzLpKmmNWlN6Hlc5r8YOuBVHqZ9vRFEQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.137.0':
     resolution: {integrity: sha512-vzFUQENy/fnbSe5DZWovq6tIBc1uhuMztanSW6rz1e9WdQE4gHwYuD7ZII6JnrJifd1R3RSoqiZbgRFlVL2tYQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.137.0':
     resolution: {integrity: sha512-SfVI14HBQs9gtLcUD5hTt5hsNbdrqSUNg9S8muN+LhVQ5nf1WwH3hAoK6B9NKgdYgWAQSXFXGiiBedQ4r/BKuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.137.0':
     resolution: {integrity: sha512-e7Ppy4FCIFNQxT/ikSeIWFoQ0l+N9vgtRBtLcyZXeolTzApyVoPqEXsYPrcdM/9i0Bwk8knvYd37vaEMxHyi6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.137.0':
     resolution: {integrity: sha512-Bho5qFwdhqsIFR7gipYEUlqvi3SRrY8sugxXig380MIaakBB1PyU9+7dBiBVScfImTNWhijUxdBwqrprGdq5WA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.137.0':
     resolution: {integrity: sha512-36mGWtg7PyFzjJwGDkH6/F4o2nIDEoKXLPr/X/lwqklkomQwJJt1I5GJVmGhovUEmgPK5WAeAZMqlFCehwiy9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.137.0':
     resolution: {integrity: sha512-/Jqx6+N7A44n2BdvUr7pXhVr2vFjs6WGH3unZRczwrfiH0H1zY0QwKQMG/dtRiTlKGDKGukznPT8lx84/oEsZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.137.0':
     resolution: {integrity: sha512-9Uj0qHNNl+OgT1UTGwF7ixIXU6T1u2SbMidmgPy/h1h/fl2gRS6YpAxxY1gwHofcWjoTwkoMFd8xs5Vuj6GOFA==}
@@ -1178,41 +1190,49 @@ packages:
     resolution: {integrity: sha512-X0AqNZgcD07Q4V3RDK18/vYOj/HQT/FnmEFGYS2jTWqY7JO13ryE3TEs3eAIgUJhBnNkpEaiXqz3VK8M7qQhWQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.21.3':
     resolution: {integrity: sha512-YkaQnaKYdbuaXvRt5Qd0GpbihzVnyfR6z1SpYfIUC6RTu4NF7lDKPjVkYb+jRI2gedVO2rVpN35Y6akG6ud4Lw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.21.3':
     resolution: {integrity: sha512-gB9HwhrPiFqUzDeEq+y/CgAijz1YdI6BnXz5GaH2Pa9cWdutchlkGFAiAuGb/PjVQpiK6NFKzFuztxrweoit7A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.21.3':
     resolution: {integrity: sha512-zjDWBlYk8QGv0H8dsPUWqkfjYIIjG2TvspGkzXL0eImbgxtZorA/klKeHyolevoT3Kvbi+1iMr9Lhrh7jf54Og==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.21.3':
     resolution: {integrity: sha512-4UfsQvacV388y1zpXL7C1x1FNYaV52JtuNRiuzrfQA2z1z6ElVrsidkGsrvQ5EgeSq1Pj7kaKqrgGkvFuxJ/tw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.21.3':
     resolution: {integrity: sha512-b5uH+HKH0MP5mNBYaK75SKsJbw52URqrx2LavYdq6wb0l3ExAG5niYRP9DWUNHdKilpaBVM2bXk9HNWrH3ew7Q==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.21.3':
     resolution: {integrity: sha512-PjYlmilBpNRh2ntXNYAK3Am5w/nPfEpnU/96iNx7CI8EzAn12J4JRiec63wHJTH31nLoCNxBg/829pN+3CfG3Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.21.3':
     resolution: {integrity: sha512-QTBAb7JuHlZ7JUEyM8UiQi2f7m/L4swBhP2TNpYIDc9Wp/wRw1G/8sl6i13aIzQAXH7LKIm294LeOHd0lQR8zA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.21.3':
     resolution: {integrity: sha512-4j1DFwjwv36ec9kds0jU/ucQ5Ha4ERO/H95BxR5JFf0kqUUAJ1kwII7XhTc1vZrkdJkvLGC9Q2MbpObpum8RBg==}
@@ -1975,56 +1995,67 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
@@ -4125,24 +4156,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -6056,7 +6091,7 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/93821cce3a0d82198d5acdf5c33cc1d2804cdbec(@floating-ui/dom@1.7.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/0ea4007e50475c216d4240a26a4915571f8c9ef4(@floating-ui/dom@1.7.5)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@phosphor-icons/react': 2.1.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-context-menu': 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -6088,20 +6123,20 @@ snapshots:
 
   '@babel/compat-data@7.27.3': {}
 
-  '@babel/core@7.28.5':
+  '@babel/core@7.28.5(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
+      '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5(supports-color@5.5.0))(supports-color@5.5.0)
       '@babel/helpers': 7.28.4
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -6126,19 +6161,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.27.1':
+  '@babel/helper-module-imports@7.27.1(supports-color@5.5.0)':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
+  '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5(supports-color@5.5.0))(supports-color@5.5.0)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/core': 7.28.5(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6159,19 +6194,19 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.5(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.5(supports-color@5.5.0))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/runtime@7.29.7': {}
@@ -6182,7 +6217,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
 
-  '@babel/traverse@7.28.5':
+  '@babel/traverse@7.28.5(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.28.5
@@ -6190,7 +6225,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6305,14 +6340,14 @@ snapshots:
       react: 19.2.7
       tslib: 2.8.1
 
-  '@electron-forge/cli@6.4.2(encoding@0.1.13)':
+  '@electron-forge/cli@6.4.2(bluebird@3.7.2)(encoding@0.1.13)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/core': 6.4.2(encoding@0.1.13)
-      '@electron-forge/shared-types': 6.4.2
-      '@electron/get': 2.0.3
+      '@electron-forge/core': 6.4.2(bluebird@3.7.2)(encoding@0.1.13)(supports-color@5.5.0)
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron/get': 2.0.3(supports-color@5.5.0)
       chalk: 4.1.2
       commander: 4.1.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 10.1.0
       listr2: 5.0.8
       semver: 7.7.2
@@ -6322,13 +6357,13 @@ snapshots:
       - enquirer
       - supports-color
 
-  '@electron-forge/core-utils@6.4.2':
+  '@electron-forge/core-utils@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/shared-types': 6.4.2
-      '@electron/rebuild': 3.7.2
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron/rebuild': 3.7.2(bluebird@3.7.2)(supports-color@5.5.0)
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       find-up: 5.0.0
       fs-extra: 10.1.0
       log-symbols: 4.1.0
@@ -6339,24 +6374,24 @@ snapshots:
       - enquirer
       - supports-color
 
-  '@electron-forge/core@6.4.2(encoding@0.1.13)':
+  '@electron-forge/core@6.4.2(bluebird@3.7.2)(encoding@0.1.13)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/core-utils': 6.4.2
-      '@electron-forge/maker-base': 6.4.2
-      '@electron-forge/plugin-base': 6.4.2
-      '@electron-forge/publisher-base': 6.4.2
-      '@electron-forge/shared-types': 6.4.2
-      '@electron-forge/template-base': 6.4.2
-      '@electron-forge/template-vite': 6.4.2
-      '@electron-forge/template-vite-typescript': 6.4.2
-      '@electron-forge/template-webpack': 6.4.2
-      '@electron-forge/template-webpack-typescript': 6.4.2
-      '@electron/get': 2.0.3
-      '@electron/rebuild': 3.7.2
+      '@electron-forge/core-utils': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/maker-base': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/plugin-base': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/publisher-base': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/template-base': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/template-vite': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/template-vite-typescript': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/template-webpack': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/template-webpack-typescript': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron/get': 2.0.3(supports-color@5.5.0)
+      '@electron/rebuild': 3.7.2(bluebird@3.7.2)(supports-color@5.5.0)
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
-      debug: 4.4.3
-      electron-packager: 17.1.2
+      debug: 4.4.3(supports-color@5.5.0)
+      electron-packager: 17.1.2(supports-color@5.5.0)
       fast-glob: 3.3.3
       filenamify: 4.3.0
       find-up: 5.0.0
@@ -6381,9 +6416,9 @@ snapshots:
       - enquirer
       - supports-color
 
-  '@electron-forge/maker-base@6.4.2':
+  '@electron-forge/maker-base@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/shared-types': 6.4.2
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
       fs-extra: 10.1.0
       which: 2.0.2
     transitivePeerDependencies:
@@ -6391,44 +6426,44 @@ snapshots:
       - enquirer
       - supports-color
 
-  '@electron-forge/maker-deb@6.4.2':
+  '@electron-forge/maker-deb@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/maker-base': 6.4.2
-      '@electron-forge/shared-types': 6.4.2
+      '@electron-forge/maker-base': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
     optionalDependencies:
-      electron-installer-debian: 3.2.0
+      electron-installer-debian: 3.2.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - bluebird
       - enquirer
       - supports-color
 
-  '@electron-forge/maker-rpm@6.4.2':
+  '@electron-forge/maker-rpm@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/maker-base': 6.4.2
-      '@electron-forge/shared-types': 6.4.2
+      '@electron-forge/maker-base': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
     optionalDependencies:
-      electron-installer-redhat: 3.4.0
+      electron-installer-redhat: 3.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - bluebird
       - enquirer
       - supports-color
 
-  '@electron-forge/maker-squirrel@6.4.2':
+  '@electron-forge/maker-squirrel@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/maker-base': 6.4.2
-      '@electron-forge/shared-types': 6.4.2
+      '@electron-forge/maker-base': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
       fs-extra: 10.1.0
     optionalDependencies:
-      electron-winstaller: 5.4.0
+      electron-winstaller: 5.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - bluebird
       - enquirer
       - supports-color
 
-  '@electron-forge/maker-zip@6.4.2':
+  '@electron-forge/maker-zip@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/maker-base': 6.4.2
-      '@electron-forge/shared-types': 6.4.2
+      '@electron-forge/maker-base': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
       cross-zip: 4.0.1
       fs-extra: 10.1.0
       got: 11.8.6
@@ -6437,37 +6472,37 @@ snapshots:
       - enquirer
       - supports-color
 
-  '@electron-forge/plugin-base@6.4.2':
+  '@electron-forge/plugin-base@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/shared-types': 6.4.2
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
     transitivePeerDependencies:
       - bluebird
       - enquirer
       - supports-color
 
-  '@electron-forge/publisher-base@6.4.2':
+  '@electron-forge/publisher-base@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/shared-types': 6.4.2
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
     transitivePeerDependencies:
       - bluebird
       - enquirer
       - supports-color
 
-  '@electron-forge/shared-types@6.4.2':
+  '@electron-forge/shared-types@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron/rebuild': 3.7.2
-      electron-packager: 17.1.2
+      '@electron/rebuild': 3.7.2(bluebird@3.7.2)(supports-color@5.5.0)
+      electron-packager: 17.1.2(supports-color@5.5.0)
       listr2: 5.0.8
     transitivePeerDependencies:
       - bluebird
       - enquirer
       - supports-color
 
-  '@electron-forge/template-base@6.4.2':
+  '@electron-forge/template-base@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/shared-types': 6.4.2
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 10.1.0
       username: 5.1.0
     transitivePeerDependencies:
@@ -6475,40 +6510,40 @@ snapshots:
       - enquirer
       - supports-color
 
-  '@electron-forge/template-vite-typescript@6.4.2':
+  '@electron-forge/template-vite-typescript@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/shared-types': 6.4.2
-      '@electron-forge/template-base': 6.4.2
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/template-base': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - bluebird
       - enquirer
       - supports-color
 
-  '@electron-forge/template-vite@6.4.2':
+  '@electron-forge/template-vite@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/shared-types': 6.4.2
-      '@electron-forge/template-base': 6.4.2
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/template-base': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - bluebird
       - enquirer
       - supports-color
 
-  '@electron-forge/template-webpack-typescript@6.4.2':
+  '@electron-forge/template-webpack-typescript@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/shared-types': 6.4.2
-      '@electron-forge/template-base': 6.4.2
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/template-base': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - bluebird
       - enquirer
       - supports-color
 
-  '@electron-forge/template-webpack@6.4.2':
+  '@electron-forge/template-webpack@6.4.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron-forge/shared-types': 6.4.2
-      '@electron-forge/template-base': 6.4.2
+      '@electron-forge/shared-types': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron-forge/template-base': 6.4.2(bluebird@3.7.2)(supports-color@5.5.0)
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - bluebird
@@ -6517,17 +6552,17 @@ snapshots:
 
   '@electron-internal/extract-zip@1.0.4': {}
 
-  '@electron-toolkit/preload@3.0.2(electron@42.6.0)':
+  '@electron-toolkit/preload@3.0.2(electron@42.6.0(supports-color@5.5.0))':
     dependencies:
-      electron: 42.6.0
+      electron: 42.6.0(supports-color@5.5.0)
 
   '@electron-toolkit/tsconfig@1.0.1(@types/node@20.19.43)':
     dependencies:
       '@types/node': 20.19.43
 
-  '@electron-toolkit/utils@4.0.0(electron@42.6.0)':
+  '@electron-toolkit/utils@4.0.0(electron@42.6.0(supports-color@5.5.0))':
     dependencies:
-      electron: 42.6.0
+      electron: 42.6.0(supports-color@5.5.0)
 
   '@electron/asar@3.2.18':
     dependencies:
@@ -6547,40 +6582,40 @@ snapshots:
       fs-extra: 9.1.0
       minimist: 1.2.8
 
-  '@electron/get@2.0.3':
+  '@electron/get@2.0.3(supports-color@5.5.0)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       env-paths: 2.2.1
       fs-extra: 8.1.0
       got: 11.8.6
       progress: 2.0.3
       semver: 6.3.1
-      sumchecker: 3.0.1
+      sumchecker: 3.0.1(supports-color@5.5.0)
     optionalDependencies:
       global-agent: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/get@5.0.0':
+  '@electron/get@5.0.0(supports-color@5.5.0)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       env-paths: 3.0.0
       graceful-fs: 4.2.11
       progress: 2.0.3
       semver: 7.7.2
-      sumchecker: 3.0.1
+      sumchecker: 3.0.1(supports-color@5.5.0)
     optionalDependencies:
       undici: 7.28.0
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
+  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.3
       glob: 8.1.0
       graceful-fs: 4.2.11
-      make-fetch-happen: 10.2.1
+      make-fetch-happen: 10.2.1(bluebird@3.7.2)(supports-color@5.5.0)
       nopt: 6.0.0
       proc-log: 2.0.1
       semver: 7.7.2
@@ -6590,25 +6625,25 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@electron/notarize@1.2.4':
+  '@electron/notarize@1.2.4(supports-color@5.5.0)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 9.1.0
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/notarize@2.5.0':
+  '@electron/notarize@2.5.0(supports-color@5.5.0)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 9.1.0
       promise-retry: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/osx-sign@1.3.1':
+  '@electron/osx-sign@1.3.1(supports-color@5.5.0)':
     dependencies:
       compare-version: 0.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
@@ -6616,10 +6651,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/osx-sign@1.3.3':
+  '@electron/osx-sign@1.3.3(supports-color@5.5.0)':
     dependencies:
       compare-version: 0.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
@@ -6627,19 +6662,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/rebuild@3.7.0':
+  '@electron/rebuild@3.7.0(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2
+      '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2(bluebird@3.7.2)(supports-color@5.5.0)
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       detect-libc: 2.0.4
       fs-extra: 10.1.0
       got: 11.8.6
       node-abi: 3.75.0
       node-api-version: 0.2.1
       ora: 5.4.1
-      read-binary-file-arch: 1.0.6
+      read-binary-file-arch: 1.0.6(supports-color@5.5.0)
       semver: 7.7.2
       tar: 6.2.1
       yargs: 17.7.2
@@ -6647,19 +6682,19 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@electron/rebuild@3.7.2':
+  '@electron/rebuild@3.7.2(bluebird@3.7.2)(supports-color@5.5.0)':
     dependencies:
-      '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2
+      '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2(bluebird@3.7.2)(supports-color@5.5.0)
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       detect-libc: 2.0.4
       fs-extra: 10.1.0
       got: 11.8.6
       node-abi: 3.75.0
       node-api-version: 0.2.1
       ora: 5.4.1
-      read-binary-file-arch: 1.0.6
+      read-binary-file-arch: 1.0.6(supports-color@5.5.0)
       semver: 7.7.2
       tar: 6.2.1
       yargs: 17.7.2
@@ -6667,11 +6702,11 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@electron/universal@1.5.1':
+  '@electron/universal@1.5.1(supports-color@5.5.0)':
     dependencies:
       '@electron/asar': 3.4.1
       '@malept/cross-spawn-promise': 1.1.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       dir-compare: 3.3.0
       fs-extra: 9.1.0
       minimatch: 3.1.2
@@ -6679,11 +6714,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/universal@2.0.1':
+  '@electron/universal@2.0.1(supports-color@5.5.0)':
     dependencies:
       '@electron/asar': 3.4.1
       '@malept/cross-spawn-promise': 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       dir-compare: 4.2.0
       fs-extra: 11.3.2
       minimatch: 9.0.5
@@ -6691,10 +6726,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/windows-sign@1.2.2':
+  '@electron/windows-sign@1.2.2(supports-color@5.5.0)':
     dependencies:
       cross-dirname: 0.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 11.3.2
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
@@ -6966,9 +7001,9 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@malept/flatpak-bundler@0.4.0':
+  '@malept/flatpak-bundler@0.4.0(supports-color@5.5.0)':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 9.1.0
       lodash: 4.17.21
       tmp-promise: 3.0.3
@@ -6977,7 +7012,7 @@ snapshots:
 
   '@microsoft/fetch-event-source@2.0.1': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@5.5.0)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.7)
       ajv: 8.17.1
@@ -6987,8 +7022,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
+      express: 5.2.1(supports-color@5.5.0)
+      express-rate-limit: 8.5.2(express@5.2.1(supports-color@5.5.0))
       hono: 4.11.7
       jose: 6.1.3
       json-schema-typed: 8.0.2
@@ -7194,14 +7229,14 @@ snapshots:
       postcss-selector-parser: 7.1.1
       ts-pattern: 5.9.0
 
-  '@pandacss/dev@1.11.4(jsdom@25.0.1)(typescript@5.9.3)':
+  '@pandacss/dev@1.11.4(jsdom@25.0.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@clack/prompts': 0.11.0
       '@pandacss/config': 1.11.4
       '@pandacss/logger': 1.11.4
-      '@pandacss/mcp': 1.11.4(jsdom@25.0.1)(typescript@5.9.3)
-      '@pandacss/node': 1.11.4(jsdom@25.0.1)(typescript@5.9.3)
-      '@pandacss/postcss': 1.11.4(jsdom@25.0.1)(typescript@5.9.3)
+      '@pandacss/mcp': 1.11.4(jsdom@25.0.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@pandacss/node': 1.11.4(jsdom@25.0.1(supports-color@5.5.0))(typescript@5.9.3)
+      '@pandacss/postcss': 1.11.4(jsdom@25.0.1(supports-color@5.5.0))(typescript@5.9.3)
       '@pandacss/preset-base': 1.11.4
       '@pandacss/preset-panda': 1.11.4
       '@pandacss/shared': 1.11.4
@@ -7214,10 +7249,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@pandacss/extractor@1.11.4(jsdom@25.0.1)(typescript@5.9.3)':
+  '@pandacss/extractor@1.11.4(jsdom@25.0.1(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
       '@pandacss/shared': 1.11.4
-      ts-evaluator: 1.2.0(jsdom@25.0.1)(typescript@5.9.3)
+      ts-evaluator: 1.2.0(jsdom@25.0.1(supports-color@5.5.0))(typescript@5.9.3)
       ts-morph: 28.0.0
     transitivePeerDependencies:
       - jsdom
@@ -7244,12 +7279,12 @@ snapshots:
       '@pandacss/types': 1.11.4
       kleur: 4.1.5
 
-  '@pandacss/mcp@1.11.4(jsdom@25.0.1)(typescript@5.9.3)':
+  '@pandacss/mcp@1.11.4(jsdom@25.0.1(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@clack/prompts': 0.11.0
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.29.0(supports-color@5.5.0)(zod@4.3.6)
       '@pandacss/logger': 1.11.4
-      '@pandacss/node': 1.11.4(jsdom@25.0.1)(typescript@5.9.3)
+      '@pandacss/node': 1.11.4(jsdom@25.0.1(supports-color@5.5.0))(typescript@5.9.3)
       '@pandacss/token-dictionary': 1.11.4
       '@pandacss/types': 1.11.4
       zod: 4.3.6
@@ -7259,13 +7294,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@pandacss/node@1.11.4(jsdom@25.0.1)(typescript@5.9.3)':
+  '@pandacss/node@1.11.4(jsdom@25.0.1(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
       '@pandacss/config': 1.11.4
       '@pandacss/core': 1.11.4
       '@pandacss/generator': 1.11.4
       '@pandacss/logger': 1.11.4
-      '@pandacss/parser': 1.11.4(jsdom@25.0.1)(typescript@5.9.3)
+      '@pandacss/parser': 1.11.4(jsdom@25.0.1(supports-color@5.5.0))(typescript@5.9.3)
       '@pandacss/plugin-lightningcss': 1.11.4
       '@pandacss/plugin-svelte': 1.11.4
       '@pandacss/plugin-vue': 1.11.4
@@ -7297,11 +7332,11 @@ snapshots:
       - jsdom
       - typescript
 
-  '@pandacss/parser@1.11.4(jsdom@25.0.1)(typescript@5.9.3)':
+  '@pandacss/parser@1.11.4(jsdom@25.0.1(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
       '@pandacss/config': 1.11.4
       '@pandacss/core': 1.11.4
-      '@pandacss/extractor': 1.11.4(jsdom@25.0.1)(typescript@5.9.3)
+      '@pandacss/extractor': 1.11.4(jsdom@25.0.1(supports-color@5.5.0))(typescript@5.9.3)
       '@pandacss/logger': 1.11.4
       '@pandacss/shared': 1.11.4
       '@pandacss/types': 1.11.4
@@ -7329,9 +7364,9 @@ snapshots:
       '@vue/compiler-sfc': 3.5.25
       magic-string: 0.30.21
 
-  '@pandacss/postcss@1.11.4(jsdom@25.0.1)(typescript@5.9.3)':
+  '@pandacss/postcss@1.11.4(jsdom@25.0.1(supports-color@5.5.0))(typescript@5.9.3)':
     dependencies:
-      '@pandacss/node': 1.11.4(jsdom@25.0.1)(typescript@5.9.3)
+      '@pandacss/node': 1.11.4(jsdom@25.0.1(supports-color@5.5.0))(typescript@5.9.3)
       postcss: 8.5.14
     transitivePeerDependencies:
       - jsdom
@@ -8109,11 +8144,11 @@ snapshots:
     optionalDependencies:
       csstype: 3.2.3
 
-  '@tanstack/router-generator@1.167.18':
+  '@tanstack/router-generator@1.167.18(supports-color@5.5.0)':
     dependencies:
       '@babel/types': 7.28.5
       '@tanstack/router-core': 1.171.14
-      '@tanstack/router-utils': 1.162.2
+      '@tanstack/router-utils': 1.162.2(supports-color@5.5.0)
       '@tanstack/virtual-file-routes': 1.162.0
       jiti: 2.7.0
       magic-string: 0.30.21
@@ -8122,14 +8157,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.25.12)(rollup@4.53.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))':
+  '@tanstack/router-plugin@1.168.19(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(esbuild@0.25.12)(rollup@4.53.3)(supports-color@5.5.0)(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@5.5.0)
       '@babel/template': 7.27.2
       '@babel/types': 7.28.5
       '@tanstack/router-core': 1.171.14
-      '@tanstack/router-generator': 1.167.18
-      '@tanstack/router-utils': 1.162.2
+      '@tanstack/router-generator': 1.167.18(supports-color@5.5.0)
+      '@tanstack/router-utils': 1.162.2(supports-color@5.5.0)
       chokidar: 5.0.0
       unplugin: 3.3.0(esbuild@0.25.12)(rollup@4.53.3)(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))
       zod: 4.4.3
@@ -8146,13 +8181,13 @@ snapshots:
       - supports-color
       - unloader
 
-  '@tanstack/router-utils@1.162.2':
+  '@tanstack/router-utils@1.162.2(supports-color@5.5.0)':
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
       ansis: 4.2.0
-      babel-dead-code-elimination: 1.0.12
+      babel-dead-code-elimination: 1.0.12(supports-color@5.5.0)
       diff: 8.0.2
       pathe: 2.0.3
       tinyglobby: 0.2.16
@@ -8497,11 +8532,11 @@ snapshots:
       '@types/node': 20.19.1
     optional: true
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(supports-color@5.5.0)(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@5.5.0)
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5(supports-color@5.5.0))
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5(supports-color@5.5.0))
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -8591,9 +8626,9 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@5.5.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8661,29 +8696,29 @@ snapshots:
 
   app-builder-bin@5.0.0-alpha.12: {}
 
-  app-builder-lib@26.0.12(dmg-builder@26.0.12)(electron-builder-squirrel-windows@26.0.12):
+  app-builder-lib@26.0.12(bluebird@3.7.2)(dmg-builder@26.0.12)(electron-builder-squirrel-windows@26.0.12)(supports-color@5.5.0):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/asar': 3.2.18
       '@electron/fuses': 1.8.0
-      '@electron/notarize': 2.5.0
-      '@electron/osx-sign': 1.3.1
-      '@electron/rebuild': 3.7.0
-      '@electron/universal': 2.0.1
-      '@malept/flatpak-bundler': 0.4.0
+      '@electron/notarize': 2.5.0(supports-color@5.5.0)
+      '@electron/osx-sign': 1.3.1(supports-color@5.5.0)
+      '@electron/rebuild': 3.7.0(bluebird@3.7.2)(supports-color@5.5.0)
+      '@electron/universal': 2.0.1(supports-color@5.5.0)
+      '@malept/flatpak-bundler': 0.4.0(supports-color@5.5.0)
       '@types/fs-extra': 9.0.13
       async-exit-hook: 2.0.1
-      builder-util: 26.0.11
-      builder-util-runtime: 9.3.1
+      builder-util: 26.0.11(supports-color@5.5.0)
+      builder-util-runtime: 9.3.1(supports-color@5.5.0)
       chromium-pickle-js: 0.2.0
       config-file-ts: 0.2.8-rc1
-      debug: 4.4.3
-      dmg-builder: 26.0.12(electron-builder-squirrel-windows@26.0.12)
+      debug: 4.4.3(supports-color@5.5.0)
+      dmg-builder: 26.0.12(bluebird@3.7.2)(electron-builder-squirrel-windows@26.0.12)(supports-color@5.5.0)
       dotenv: 16.5.0
       dotenv-expand: 11.0.7
       ejs: 3.1.10
-      electron-builder-squirrel-windows: 26.0.12(dmg-builder@26.0.12)
-      electron-publish: 26.0.11
+      electron-builder-squirrel-windows: 26.0.12(bluebird@3.7.2)(dmg-builder@26.0.12)(supports-color@5.5.0)
+      electron-publish: 26.0.11(supports-color@5.5.0)
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
       is-ci: 3.0.1
@@ -8767,27 +8802,27 @@ snapshots:
 
   author-regex@1.0.0: {}
 
-  axios@0.25.0:
+  axios@0.25.0(debug@4.4.3(supports-color@5.5.0)):
     dependencies:
-      follow-redirects: 1.15.9
+      follow-redirects: 1.15.9(debug@4.4.3(supports-color@5.5.0))
     transitivePeerDependencies:
       - debug
 
-  axios@1.18.1:
+  axios@1.18.1(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@5.5.0))
       form-data: 4.0.5
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@5.5.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  babel-dead-code-elimination@1.0.12:
+  babel-dead-code-elimination@1.0.12(supports-color@5.5.0):
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.5(supports-color@5.5.0)
       '@babel/parser': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -8817,11 +8852,11 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@2.2.2:
+  body-parser@2.2.2(supports-color@5.5.0):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -8874,25 +8909,25 @@ snapshots:
 
   buffers@0.1.1: {}
 
-  builder-util-runtime@9.3.1:
+  builder-util-runtime@9.3.1(supports-color@5.5.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       sax: 1.4.1
     transitivePeerDependencies:
       - supports-color
 
-  builder-util@26.0.11:
+  builder-util@26.0.11(supports-color@5.5.0):
     dependencies:
       7zip-bin: 5.2.0
       '@types/debug': 4.1.12
       app-builder-bin: 5.0.0-alpha.12
-      builder-util-runtime: 9.3.1
+      builder-util-runtime: 9.3.1(supports-color@5.5.0)
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 10.1.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@5.5.0)
+      https-proxy-agent: 7.0.6(supports-color@5.5.0)
       is-ci: 3.0.1
       js-yaml: 4.1.0
       sanitize-filename: 1.6.3
@@ -8907,7 +8942,7 @@ snapshots:
 
   cac@6.7.14: {}
 
-  cacache@16.1.3:
+  cacache@16.1.3(bluebird@3.7.2):
     dependencies:
       '@npmcli/fs': 2.1.2
       '@npmcli/move-file': 2.0.1
@@ -8922,7 +8957,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       mkdirp: 1.0.4
       p-map: 4.0.0
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1(bluebird@3.7.2)
       rimraf: 3.0.2
       ssri: 9.0.1
       tar: 6.2.1
@@ -9180,9 +9215,11 @@ snapshots:
 
   dayjs@1.11.13: {}
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@5.5.0):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 5.5.0
 
   debug@3.2.7(supports-color@5.5.0):
     dependencies:
@@ -9190,17 +9227,23 @@ snapshots:
     optionalDependencies:
       supports-color: 5.5.0
 
-  debug@4.3.4:
+  debug@4.3.4(supports-color@5.5.0):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
+      supports-color: 5.5.0
 
-  debug@4.4.1:
+  debug@4.4.1(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 5.5.0
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 5.5.0
 
   decimal.js@10.6.0: {}
 
@@ -9259,11 +9302,11 @@ snapshots:
       minimatch: 3.1.2
       p-limit: 3.1.0
 
-  dmg-builder@26.0.12(electron-builder-squirrel-windows@26.0.12):
+  dmg-builder@26.0.12(bluebird@3.7.2)(electron-builder-squirrel-windows@26.0.12)(supports-color@5.5.0):
     dependencies:
-      app-builder-lib: 26.0.12(dmg-builder@26.0.12)(electron-builder-squirrel-windows@26.0.12)
-      builder-util: 26.0.11
-      builder-util-runtime: 9.3.1
+      app-builder-lib: 26.0.12(bluebird@3.7.2)(dmg-builder@26.0.12)(electron-builder-squirrel-windows@26.0.12)(supports-color@5.5.0)
+      builder-util: 26.0.11(supports-color@5.5.0)
+      builder-util-runtime: 9.3.1(supports-color@5.5.0)
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
       js-yaml: 4.1.0
@@ -9314,23 +9357,23 @@ snapshots:
     dependencies:
       jake: 10.9.2
 
-  electron-builder-squirrel-windows@26.0.12(dmg-builder@26.0.12):
+  electron-builder-squirrel-windows@26.0.12(bluebird@3.7.2)(dmg-builder@26.0.12)(supports-color@5.5.0):
     dependencies:
-      app-builder-lib: 26.0.12(dmg-builder@26.0.12)(electron-builder-squirrel-windows@26.0.12)
-      builder-util: 26.0.11
-      electron-winstaller: 5.4.0
+      app-builder-lib: 26.0.12(bluebird@3.7.2)(dmg-builder@26.0.12)(electron-builder-squirrel-windows@26.0.12)(supports-color@5.5.0)
+      builder-util: 26.0.11(supports-color@5.5.0)
+      electron-winstaller: 5.4.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - bluebird
       - dmg-builder
       - supports-color
 
-  electron-builder@26.0.12(electron-builder-squirrel-windows@26.0.12):
+  electron-builder@26.0.12(bluebird@3.7.2)(electron-builder-squirrel-windows@26.0.12)(supports-color@5.5.0):
     dependencies:
-      app-builder-lib: 26.0.12(dmg-builder@26.0.12)(electron-builder-squirrel-windows@26.0.12)
-      builder-util: 26.0.11
-      builder-util-runtime: 9.3.1
+      app-builder-lib: 26.0.12(bluebird@3.7.2)(dmg-builder@26.0.12)(electron-builder-squirrel-windows@26.0.12)(supports-color@5.5.0)
+      builder-util: 26.0.11(supports-color@5.5.0)
+      builder-util-runtime: 9.3.1(supports-color@5.5.0)
       chalk: 4.1.2
-      dmg-builder: 26.0.12(electron-builder-squirrel-windows@26.0.12)
+      dmg-builder: 26.0.12(bluebird@3.7.2)(electron-builder-squirrel-windows@26.0.12)(supports-color@5.5.0)
       fs-extra: 10.1.0
       is-ci: 3.0.1
       lazy-val: 1.0.5
@@ -9341,10 +9384,10 @@ snapshots:
       - electron-builder-squirrel-windows
       - supports-color
 
-  electron-debug@3.2.0:
+  electron-debug@3.2.0(supports-color@5.5.0):
     dependencies:
       electron-is-dev: 1.2.0
-      electron-localshortcut: 3.2.1
+      electron-localshortcut: 3.2.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9355,11 +9398,11 @@ snapshots:
       tslib: 2.8.1
       unzip-crx-3: 0.2.0
 
-  electron-installer-common@0.10.4:
+  electron-installer-common@0.10.4(supports-color@5.5.0):
     dependencies:
       '@electron/asar': 3.4.1
       '@malept/cross-spawn-promise': 1.1.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 9.1.0
       glob: 7.2.3
       lodash: 4.17.21
@@ -9372,11 +9415,11 @@ snapshots:
       - supports-color
     optional: true
 
-  electron-installer-debian@3.2.0:
+  electron-installer-debian@3.2.0(supports-color@5.5.0):
     dependencies:
       '@malept/cross-spawn-promise': 1.1.1
-      debug: 4.4.3
-      electron-installer-common: 0.10.4
+      debug: 4.4.3(supports-color@5.5.0)
+      electron-installer-common: 0.10.4(supports-color@5.5.0)
       fs-extra: 9.1.0
       get-folder-size: 2.0.1
       lodash: 4.17.21
@@ -9386,11 +9429,11 @@ snapshots:
       - supports-color
     optional: true
 
-  electron-installer-redhat@3.4.0:
+  electron-installer-redhat@3.4.0(supports-color@5.5.0):
     dependencies:
       '@malept/cross-spawn-promise': 1.1.1
-      debug: 4.4.3
-      electron-installer-common: 0.10.4
+      debug: 4.4.3(supports-color@5.5.0)
+      electron-installer-common: 0.10.4(supports-color@5.5.0)
       fs-extra: 9.1.0
       lodash: 4.17.21
       word-wrap: 1.2.5
@@ -9403,29 +9446,29 @@ snapshots:
 
   electron-is-dev@1.2.0: {}
 
-  electron-localshortcut@3.2.1:
+  electron-localshortcut@3.2.1(supports-color@5.5.0):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@5.5.0)
       electron-is-accelerator: 0.1.2
       keyboardevent-from-electron-accelerator: 2.0.0
       keyboardevents-areequal: 0.2.2
     transitivePeerDependencies:
       - supports-color
 
-  electron-packager@17.1.2:
+  electron-packager@17.1.2(supports-color@5.5.0):
     dependencies:
       '@electron/asar': 3.4.1
-      '@electron/get': 2.0.3
-      '@electron/notarize': 1.2.4
-      '@electron/osx-sign': 1.3.3
-      '@electron/universal': 1.5.1
+      '@electron/get': 2.0.3(supports-color@5.5.0)
+      '@electron/notarize': 1.2.4(supports-color@5.5.0)
+      '@electron/osx-sign': 1.3.3(supports-color@5.5.0)
+      '@electron/universal': 1.5.1(supports-color@5.5.0)
       cross-spawn-windows-exe: 1.2.0
-      debug: 4.4.3
-      extract-zip: 2.0.1
+      debug: 4.4.3(supports-color@5.5.0)
+      extract-zip: 2.0.1(supports-color@5.5.0)
       filenamify: 4.3.0
       fs-extra: 11.3.2
-      galactus: 1.0.0
-      get-package-info: 1.0.0
+      galactus: 1.0.0(supports-color@5.5.0)
+      get-package-info: 1.0.0(supports-color@5.5.0)
       junk: 3.1.0
       parse-author: 2.0.0
       plist: 3.1.0
@@ -9436,11 +9479,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-publish@26.0.11:
+  electron-publish@26.0.11(supports-color@5.5.0):
     dependencies:
       '@types/fs-extra': 9.0.13
-      builder-util: 26.0.11
-      builder-util-runtime: 9.3.1
+      builder-util: 26.0.11(supports-color@5.5.0)
+      builder-util-runtime: 9.3.1(supports-color@5.5.0)
       chalk: 4.1.2
       form-data: 4.0.5
       fs-extra: 10.1.0
@@ -9449,18 +9492,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-squirrel-startup@1.0.1:
+  electron-squirrel-startup@1.0.1(supports-color@5.5.0):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   electron-to-chromium@1.5.283: {}
 
-  electron-vite@5.0.0(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0)):
+  electron-vite@5.0.0(supports-color@5.5.0)(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0)):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.5)
+      '@babel/core': 7.28.5(supports-color@5.5.0)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.5(supports-color@5.5.0))
       cac: 6.7.14
       esbuild: 0.25.12
       magic-string: 0.30.21
@@ -9469,22 +9512,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-winstaller@5.4.0:
+  electron-winstaller@5.4.0(supports-color@5.5.0):
     dependencies:
       '@electron/asar': 3.4.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 7.0.1
       lodash: 4.17.21
       temp: 0.9.4
     optionalDependencies:
-      '@electron/windows-sign': 1.2.2
+      '@electron/windows-sign': 1.2.2(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  electron@42.6.0:
+  electron@42.6.0(supports-color@5.5.0):
     dependencies:
       '@electron-internal/extract-zip': 1.0.4
-      '@electron/get': 5.0.0
+      '@electron/get': 5.0.0(supports-color@5.5.0)
       '@types/node': 24.13.2
     transitivePeerDependencies:
       - supports-color
@@ -9664,25 +9707,25 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  express-rate-limit@8.5.2(express@5.2.1):
+  express-rate-limit@8.5.2(express@5.2.1(supports-color@5.5.0)):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@5.5.0)
       ip-address: 10.2.0
 
-  express@5.2.1:
+  express@5.2.1(supports-color@5.5.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.2.2(supports-color@5.5.0)
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@5.5.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -9693,9 +9736,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.14.1
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@5.5.0)
+      send: 1.2.1(supports-color@5.5.0)
+      serve-static: 2.2.1(supports-color@5.5.0)
       statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
@@ -9704,9 +9747,9 @@ snapshots:
 
   exsolve@1.0.8: {}
 
-  extract-zip@2.0.1:
+  extract-zip@2.0.1(supports-color@5.5.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -9770,9 +9813,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@5.5.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -9795,16 +9838,20 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  flora-colossus@2.0.0:
+  flora-colossus@2.0.0(supports-color@5.5.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - supports-color
 
-  follow-redirects@1.15.9: {}
+  follow-redirects@1.15.9(debug@4.4.3(supports-color@5.5.0)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@5.5.0)
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@5.5.0)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@5.5.0)
 
   foreground-child@3.3.1:
     dependencies:
@@ -9878,10 +9925,10 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  galactus@1.0.0:
+  galactus@1.0.0(supports-color@5.5.0):
     dependencies:
-      debug: 4.4.3
-      flora-colossus: 2.0.0
+      debug: 4.4.3(supports-color@5.5.0)
+      flora-colossus: 2.0.0(supports-color@5.5.0)
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - supports-color
@@ -9918,10 +9965,10 @@ snapshots:
 
   get-nonce@1.0.1: {}
 
-  get-package-info@1.0.0:
+  get-package-info@1.0.0(supports-color@5.5.0):
     dependencies:
       bluebird: 3.7.2
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@5.5.0)
       lodash.get: 4.4.2
       read-pkg-up: 2.0.0
     transitivePeerDependencies:
@@ -10091,18 +10138,18 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@5.0.0:
+  http-proxy-agent@5.0.0(supports-color@5.5.0):
     dependencies:
       '@tootallnate/once': 2.0.1
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@5.5.0):
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10111,17 +10158,17 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@5.5.0):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@5.5.0):
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10275,15 +10322,15 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@25.0.1:
+  jsdom@25.0.1(supports-color@5.5.0):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       form-data: 4.0.5
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@5.5.0)
+      https-proxy-agent: 7.0.6(supports-color@5.5.0)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -10475,11 +10522,11 @@ snapshots:
 
   linkifyjs@4.3.3: {}
 
-  lint-staged@13.3.0:
+  lint-staged@13.3.0(supports-color@5.5.0):
     dependencies:
       chalk: 5.3.0
       commander: 11.0.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@5.5.0)
       execa: 7.2.0
       lilconfig: 2.1.0
       listr2: 6.6.1
@@ -10609,13 +10656,13 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  make-fetch-happen@10.2.1:
+  make-fetch-happen@10.2.1(bluebird@3.7.2)(supports-color@5.5.0):
     dependencies:
       agentkeepalive: 4.6.0
-      cacache: 16.1.3
+      cacache: 16.1.3(bluebird@3.7.2)
       http-cache-semantics: 4.2.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
+      http-proxy-agent: 5.0.0(supports-color@5.5.0)
+      https-proxy-agent: 5.0.1(supports-color@5.5.0)
       is-lambda: 1.0.1
       lru-cache: 7.18.3
       minipass: 3.3.6
@@ -10625,7 +10672,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       negotiator: 0.6.4
       promise-retry: 2.0.1
-      socks-proxy-agent: 7.0.0
+      socks-proxy-agent: 7.0.0(supports-color@5.5.0)
       ssri: 9.0.1
     transitivePeerDependencies:
       - bluebird
@@ -11150,7 +11197,9 @@ snapshots:
 
   progress@2.0.3: {}
 
-  promise-inflight@1.0.1: {}
+  promise-inflight@1.0.1(bluebird@3.7.2):
+    optionalDependencies:
+      bluebird: 3.7.2
 
   promise-retry@2.0.1:
     dependencies:
@@ -11324,9 +11373,9 @@ snapshots:
 
   react@19.2.7: {}
 
-  read-binary-file-arch@1.0.6:
+  read-binary-file-arch@1.0.6(supports-color@5.5.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11479,9 +11528,9 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
-  router@2.2.0:
+  router@2.2.0(supports-color@5.5.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -11541,9 +11590,9 @@ snapshots:
 
   semver@7.7.2: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@5.5.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -11568,12 +11617,12 @@ snapshots:
 
   seroval@1.5.4: {}
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@5.5.0):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11660,10 +11709,10 @@ snapshots:
 
   smol-toml@1.6.1: {}
 
-  socks-proxy-agent@7.0.0:
+  socks-proxy-agent@7.0.0(supports-color@5.5.0):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@5.5.0)
       socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
@@ -11763,9 +11812,9 @@ snapshots:
 
   sudo-prompt@9.2.1: {}
 
-  sumchecker@3.0.1:
+  sumchecker@3.0.1(supports-color@5.5.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11887,14 +11936,14 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
-  ts-evaluator@1.2.0(jsdom@25.0.1)(typescript@5.9.3):
+  ts-evaluator@1.2.0(jsdom@25.0.1(supports-color@5.5.0))(typescript@5.9.3):
     dependencies:
       ansi-colors: 4.1.3
       crosspath: 2.0.0
       object-path: 0.11.8
       typescript: 5.9.3
     optionalDependencies:
-      jsdom: 25.0.1
+      jsdom: 25.0.1(supports-color@5.5.0)
 
   ts-morph@28.0.0:
     dependencies:
@@ -12060,7 +12109,7 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.9.0
 
-  vitest@4.1.9(@types/node@20.19.43)(jsdom@25.0.1)(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@20.19.43)(jsdom@25.0.1(supports-color@5.5.0))(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@6.4.3(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.31.1)(tsx@4.20.6)(yaml@2.9.0))
@@ -12084,7 +12133,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.43
-      jsdom: 25.0.1
+      jsdom: 25.0.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - msw
 
@@ -12096,9 +12145,9 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wait-on@6.0.1:
+  wait-on@6.0.1(debug@4.4.3(supports-color@5.5.0)):
     dependencies:
-      axios: 0.25.0
+      axios: 0.25.0(debug@4.4.3(supports-color@5.5.0))
       joi: 17.13.3
       lodash: 4.17.21
       minimist: 1.2.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ allowBuilds:
   # protocol URLs, so pnpm's repo-URL allowBuilds form (11.11.0+) doesn't
   # match them — the exact commit hash below must be bumped by hand whenever
   # @aymurai/ui's pinned tag changes (see package.json).
-  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/0ea4007e50475c216d4240a26a4915571f8c9ef4': true
+  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/5125acfc2b2de1ff996cbf46d6eaefb08cc0204c': true
   '@biomejs/biome': true
   agent-browser: false
   electron: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ allowBuilds:
   # protocol URLs, so pnpm's repo-URL allowBuilds form (11.11.0+) doesn't
   # match them — the exact commit hash below must be bumped by hand whenever
   # @aymurai/ui's pinned tag changes (see package.json).
-  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/93821cce3a0d82198d5acdf5c33cc1d2804cdbec': true
+  '@aymurai/ui@https://codeload.github.com/AymurAI/ui-components/tar.gz/0ea4007e50475c216d4240a26a4915571f8c9ef4': true
   '@biomejs/biome': true
   agent-browser: false
   electron: true

--- a/src/renderer/src/components/voice-to-text/transcription-editor/selection-toolbar.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/selection-toolbar.tsx
@@ -169,10 +169,9 @@ const toolbar = css({
   display: "flex",
   alignItems: "center",
   gap: "2",
-  // NOTE: bracketed hex — no dark-surface token exists; flagged for future tokenisation
-  bg: "[#26244a]",
-  borderRadius: "[11px]",
-  boxShadow: "[0 8px 24px rgba(28,26,60,.28)]",
+  bg: "bg.overlay-dark",
+  borderRadius: "md",
+  boxShadow: "menu",
   px: "3",
   py: "2",
   zIndex: "100",
@@ -191,15 +190,16 @@ const assignBtn = css({
   gap: "[6px]",
   bg: "transparent",
   border: "[none]",
-  // NOTE: bracketed hex — white text on dark toolbar; no onbutton token for dark surface
-  color: "[#ffffff]",
+  color: "text.on-overlay-dark",
   fontSize: "[14px]",
   fontWeight: "[600]",
   cursor: "pointer",
   padding: "[4px 8px]",
-  borderRadius: "[7px]",
+  borderRadius: "sm",
   whiteSpace: "nowrap",
   "&:hover": {
+    // NOTE: bracketed — un token de hover sobre superficie oscura para un solo
+    // componente sería sobre-ingeniería.
     bg: "[rgba(255,255,255,0.12)]",
   },
 });

--- a/src/renderer/src/components/voice-to-text/transcription-editor/selection-toolbar.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/selection-toolbar.tsx
@@ -198,8 +198,8 @@ const assignBtn = css({
   borderRadius: "sm",
   whiteSpace: "nowrap",
   "&:hover": {
-    // NOTE: bracketed — un token de hover sobre superficie oscura para un solo
-    // componente sería sobre-ingeniería.
+    // NOTE: bracketed — a hover token for a dark surface used by a single
+    // component would be over-engineering.
     bg: "[rgba(255,255,255,0.12)]",
   },
 });

--- a/src/renderer/src/components/voice-to-text/transcription-editor/speaker-picker.test.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/speaker-picker.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Transcription } from "@/types/transcription";
+import SpeakerPicker from "./speaker-picker";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const dispatch = vi.fn();
+vi.mock("@/hooks/useTranscriptions", () => ({
+  useTranscriptionDispatch: () => dispatch,
+}));
+
+const transcription: Transcription = {
+  id: "doc-1",
+  title: "T",
+  audioFileName: "a.mp3",
+  audioDurationMs: 30_000,
+  audioObjectUrl: "blob:x",
+  speakers: [
+    { id: "s1", label: "Persona 1", initials: "P1", color: "violet" },
+    { id: "s2", label: "Persona 2", initials: "P2", color: "green" },
+  ],
+  turns: [],
+  source: "asr",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("SpeakerPicker", () => {
+  beforeEach(() => dispatch.mockClear());
+
+  it("step 1 lists identified speakers with the current one marked selected", () => {
+    render(
+      <SpeakerPicker
+        transcription={transcription}
+        currentSpeakerId="s2"
+        onPick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Persona 1" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Persona 2" })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+  });
+
+  it("picking an existing speaker calls onPick with its id and closes", () => {
+    const onPick = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <SpeakerPicker
+        transcription={transcription}
+        currentSpeakerId="s2"
+        onPick={onPick}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Persona 1" }));
+    expect(onPick).toHaveBeenCalledWith("s1");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("'Nuevo' advances to the roles step", () => {
+    render(
+      <SpeakerPicker
+        transcription={transcription}
+        currentSpeakerId="s1"
+        onPick={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "speakerPicker.new" }));
+    expect(screen.getByRole("button", { name: "Juez/a" })).toBeInTheDocument();
+  });
+
+  it("picking a role creates the speaker and calls onPick with its new id", () => {
+    const onPick = vi.fn();
+    render(
+      <SpeakerPicker
+        transcription={transcription}
+        currentSpeakerId="s1"
+        onPick={onPick}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "speakerPicker.new" }));
+    fireEvent.click(screen.getByRole("button", { name: "Fiscal" }));
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "ADD_SPEAKER",
+        payload: expect.objectContaining({
+          speaker: expect.objectContaining({ label: "Fiscal" }),
+        }),
+      }),
+    );
+    expect(onPick).toHaveBeenCalledTimes(1);
+  });
+
+  it("'Nueva persona' reveals a free-text input, and Enter creates and picks it", () => {
+    const onPick = vi.fn();
+    render(
+      <SpeakerPicker
+        transcription={transcription}
+        currentSpeakerId="s1"
+        onPick={onPick}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "speakerPicker.new" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "speakerPicker.newPerson" }),
+    );
+    const input = screen.getByPlaceholderText(
+      "speakerPicker.newPersonPlaceholder",
+    );
+    fireEvent.change(input, { target: { value: "Dra. Silva" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "ADD_SPEAKER",
+        payload: expect.objectContaining({
+          speaker: expect.objectContaining({ label: "Dra. Silva" }),
+        }),
+      }),
+    );
+    expect(onPick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/src/components/voice-to-text/transcription-editor/speaker-picker.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/speaker-picker.tsx
@@ -149,7 +149,7 @@ export default function SpeakerPicker({
     onClose();
   };
 
-  // Contenedor externo: sólo posicionamiento. La card la trae PersonMenu.
+  // Outer container: positioning only. PersonMenu brings its own card.
   const anchor = css({ position: "absolute", zIndex: "50" });
 
   const nameInput = (

--- a/src/renderer/src/components/voice-to-text/transcription-editor/speaker-picker.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/speaker-picker.tsx
@@ -1,8 +1,7 @@
-import { Check, Plus } from "phosphor-react";
+import { PersonMenu } from "@aymurai/ui";
 import { type CSSProperties, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import SpeakerAvatar from "@/components/voice-to-text/speaker-avatar";
 import { useTranscriptionDispatch } from "@/hooks/useTranscriptions";
 import { computeInitials } from "@/reducers/transcription";
 import { addSpeaker } from "@/reducers/transcription/actions";
@@ -14,70 +13,6 @@ import type {
   Transcription,
 } from "@/types/transcription";
 import { SPEAKER_PALETTE } from "@/types/transcription";
-
-const popover = css({
-  bg: "bg.secondary",
-  borderRadius: "[14px]",
-  // NOTE: bracketed raw hex — no shadow token exists for this specific elevation
-  boxShadow: "[0 16px 44px rgba(28,26,60,.18),0 0 0 1px rgba(28,26,60,.06)]",
-  padding: "2",
-  minWidth: "[270px]",
-  maxHeight: "[440px]",
-  overflowY: "auto",
-  position: "absolute",
-  zIndex: "50",
-});
-
-const sectionLabel = css({
-  fontSize: "[11px]",
-  fontWeight: "[700]",
-  letterSpacing: "[0.6px]",
-  textTransform: "uppercase",
-  color: "text.lighter",
-  padding: "[8px 10px 6px]",
-  display: "block",
-});
-
-const itemBase = css({
-  display: "flex",
-  alignItems: "center",
-  gap: "[11px]",
-  width: "full",
-  border: "[none]",
-  bg: "transparent",
-  padding: "[8px 10px]",
-  borderRadius: "[9px]",
-  cursor: "pointer",
-  textAlign: "left",
-  "&:hover": { bg: "bg.primary" },
-});
-
-const itemActive = css({
-  display: "flex",
-  alignItems: "center",
-  gap: "[11px]",
-  width: "full",
-  border: "[none]",
-  bg: "bg.primary-alternative",
-  padding: "[8px 10px]",
-  borderRadius: "[9px]",
-  cursor: "pointer",
-  textAlign: "left",
-  "&:hover": { bg: "bg.primary" },
-});
-
-const itemName = css({
-  fontSize: "[15px]",
-  fontWeight: "[600]",
-  color: "text.default",
-  flex: "[1]",
-});
-
-const divider = css({
-  border: "[0]",
-  borderTop: "primary",
-  margin: "[6px 4px]",
-});
 
 const newPersonRow = css({
   display: "flex",
@@ -112,29 +47,6 @@ const createBtn = css({
   "&:hover": { opacity: "0.85" },
 });
 
-const newPersonBtn = css({
-  display: "flex",
-  alignItems: "center",
-  gap: "[11px]",
-  width: "full",
-  border: "[none]",
-  bg: "transparent",
-  padding: "[8px 10px]",
-  borderRadius: "[9px]",
-  cursor: "pointer",
-  textAlign: "left",
-  color: "brand.primary",
-  fontWeight: "[600]",
-  fontSize: "[15px]",
-  "&:hover": { bg: "bg.primary" },
-});
-
-const checkIcon = css({
-  color: "brand.primary",
-  flexShrink: "0",
-  ml: "auto",
-});
-
 export interface SpeakerPickerProps {
   transcription: Transcription;
   currentSpeakerId?: string;
@@ -154,6 +66,7 @@ export default function SpeakerPicker({
 }: SpeakerPickerProps) {
   const { t } = useTranslation("voice-to-text");
   const dispatch = useTranscriptionDispatch();
+  const [step, setStep] = useState<"people" | "roles">("people");
   const [showNewRow, setShowNewRow] = useState(false);
   const [newName, setNewName] = useState("");
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -236,89 +149,73 @@ export default function SpeakerPicker({
     onClose();
   };
 
+  // Contenedor externo: sólo posicionamiento. La card la trae PersonMenu.
+  const anchor = css({ position: "absolute", zIndex: "50" });
+
+  const nameInput = (
+    <div className={newPersonRow}>
+      <input
+        ref={inputRef}
+        className={newPersonInput}
+        placeholder={t("speakerPicker.newPersonPlaceholder")}
+        value={newName}
+        onChange={(e) => setNewName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") handleCreate();
+          if (e.key === "Escape") {
+            setShowNewRow(false);
+            setNewName("");
+          }
+        }}
+      />
+      <button type="button" className={createBtn} onClick={handleCreate}>
+        {t("speakerPicker.create")}
+      </button>
+    </div>
+  );
+
   return (
     <div
       ref={popoverRef}
-      className={`${popover}${className ? ` ${className}` : ""}`}
+      className={`${anchor}${className ? ` ${className}` : ""}`}
       style={style}
       onPointerDown={(e) => e.stopPropagation()}
     >
-      {/* Existing speakers */}
-      {speakers.length > 0 && (
-        <>
-          <span className={sectionLabel}>{t("speakerPicker.people")}</span>
-          {speakers.map((s) => {
-            const isCurrent = s.id === currentSpeakerId;
-            return (
-              <button
-                key={s.id}
-                type="button"
-                className={isCurrent ? itemActive : itemBase}
-                onClick={() => handleExistingPick(s.id)}
-              >
-                <SpeakerAvatar speaker={s} size="sm" />
-                <span className={itemName}>{s.label}</span>
-                {isCurrent && (
-                  <Check size={16} weight="bold" className={checkIcon} />
-                )}
-              </button>
-            );
-          })}
-        </>
-      )}
-
-      {/* Suggested speakers */}
-      {availableSuggested.length > 0 && (
-        <>
-          {speakers.length > 0 && <hr className={divider} />}
-          <span className={sectionLabel}>{t("speakerPicker.suggested")}</span>
-          {availableSuggested.map((sg) => (
-            <button
-              key={sg.id}
-              type="button"
-              className={itemBase}
-              onClick={() =>
-                handleSuggestedPick(sg.label, sg.color, sg.initials)
-              }
-            >
-              <SpeakerAvatar speaker={sg} size="sm" />
-              <span className={itemName}>{sg.label}</span>
-            </button>
-          ))}
-        </>
-      )}
-
-      {/* New person */}
-      <hr className={divider} />
-      {!showNewRow ? (
-        <button
-          type="button"
-          className={newPersonBtn}
-          onClick={() => setShowNewRow(true)}
-        >
-          <Plus size={16} weight="bold" />
-          {t("speakerPicker.newPerson")}
-        </button>
+      {step === "people" ? (
+        <PersonMenu
+          aria-label={t("speakerPicker.people")}
+          options={speakers.map((s) => ({
+            id: s.id,
+            initials: s.initials,
+            name: s.label,
+            color: s.color,
+          }))}
+          selectedIndex={speakers.findIndex((s) => s.id === currentSpeakerId)}
+          onSelectOption={(index) => {
+            const speaker = speakers[index];
+            if (speaker) handleExistingPick(speaker.id);
+          }}
+          footerLabel={t("speakerPicker.new")}
+          onFooterAction={() => setStep("roles")}
+        />
       ) : (
-        <div className={newPersonRow}>
-          <input
-            ref={inputRef}
-            className={newPersonInput}
-            placeholder={t("speakerPicker.newPersonPlaceholder")}
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleCreate();
-              if (e.key === "Escape") {
-                setShowNewRow(false);
-                setNewName("");
-              }
-            }}
-          />
-          <button type="button" className={createBtn} onClick={handleCreate}>
-            {t("speakerPicker.create")}
-          </button>
-        </div>
+        <PersonMenu
+          aria-label={t("speakerPicker.suggested")}
+          options={availableSuggested.map((sg) => ({
+            id: sg.id,
+            initials: sg.initials,
+            name: sg.label,
+            color: sg.color,
+          }))}
+          onSelectOption={(index) => {
+            const role = availableSuggested[index];
+            if (role)
+              handleSuggestedPick(role.label, role.color, role.initials);
+          }}
+          footerLabel={showNewRow ? undefined : t("speakerPicker.newPerson")}
+          onFooterAction={() => setShowNewRow(true)}
+          footerSlot={showNewRow ? nameInput : undefined}
+        />
       )}
     </div>
   );

--- a/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.test.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.test.tsx
@@ -342,6 +342,7 @@ describe("TurnSidePanel new-person numbering", () => {
     };
     render(<TurnSidePanel transcription={renamedOnly} activeTurnId="a" />);
     fireEvent.click(screen.getByText("Nuevo"));
+    fireEvent.click(screen.getByRole("button", { name: "Nueva persona" }));
 
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -368,6 +369,7 @@ describe("TurnSidePanel new-person numbering", () => {
       <TurnSidePanel transcription={withCustomAndPersona} activeTurnId="a" />,
     );
     fireEvent.click(screen.getByText("Nuevo"));
+    fireEvent.click(screen.getByRole("button", { name: "Nueva persona" }));
 
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -377,5 +379,89 @@ describe("TurnSidePanel new-person numbering", () => {
         }),
       }),
     );
+  });
+});
+
+describe("TurnSidePanel role options menu", () => {
+  beforeEach(() => dispatch.mockClear());
+
+  it("lists only the roles whose label is not already taken", () => {
+    const withFiscal: Transcription = {
+      ...multiSpeakerTranscription,
+      speakers: [
+        { id: "s1", label: "Persona 1", initials: "P1", color: "violet" },
+        { id: "s2", label: "Fiscal", initials: "FI", color: "green" },
+      ],
+    };
+    render(<TurnSidePanel transcription={withFiscal} activeTurnId="a" />);
+    fireEvent.click(screen.getByText("Nuevo"));
+
+    expect(screen.getByRole("button", { name: "Juez/a" })).toBeTruthy();
+    // "Fiscal" ya existe como orador: aparece como pill, no como opción.
+    expect(screen.queryByRole("button", { name: "Fiscal" })).toBeNull();
+  });
+
+  it("creates the speaker and reassigns when the current speaker has a single turn", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="b" // "b" es el único turno de s2
+      />,
+    );
+    fireEvent.click(screen.getByText("Nuevo"));
+    fireEvent.click(screen.getByRole("button", { name: "Juez/a" }));
+
+    expect(screen.queryByText("sidePanel.scopeDialog.title")).toBeNull();
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "ADD_SPEAKER",
+        payload: expect.objectContaining({
+          speaker: expect.objectContaining({ label: "Juez/a" }),
+        }),
+      }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "REASSIGN_TURN_SPEAKER",
+        payload: expect.objectContaining({ turnId: "b" }),
+      }),
+    );
+  });
+
+  it("prompts for scope when picking a role for a speaker with several turns", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="a" // s1 tiene los turnos a y c
+      />,
+    );
+    fireEvent.click(screen.getByText("Nuevo"));
+    fireEvent.click(screen.getByRole("button", { name: "Juez/a" }));
+
+    expect(screen.getByText("sidePanel.scopeDialog.title")).toBeTruthy();
+    fireEvent.click(screen.getByText("sidePanel.scopeDialog.allTurns"));
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "RENAME_SPEAKER_GLOBAL",
+        payload: expect.objectContaining({
+          speakerId: "s1",
+          newLabel: "Juez/a",
+        }),
+      }),
+    );
+  });
+
+  it("does not dispatch when the already-current speaker's pill is clicked", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="a"
+      />,
+    );
+    // "Persona 1" also appears in the "Turno seleccionado" header (it always
+    // shows the current speaker's name), so getAllByText + the pill instance
+    // (index 1) is used to disambiguate from the header (index 0).
+    fireEvent.click(screen.getAllByText("Persona 1")[1]); // s1 ya es el orador del turno "a"
+    expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.test.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.test.tsx
@@ -319,7 +319,7 @@ describe("TurnSidePanel bulk-apply scope prompt", () => {
     );
   });
 
-  it("dismisses without dispatching on cancel", () => {
+  it("dismisses without dispatching when the dialog is closed with Escape", () => {
     render(
       <TurnSidePanel
         transcription={multiSpeakerTranscription}
@@ -327,8 +327,35 @@ describe("TurnSidePanel bulk-apply scope prompt", () => {
       />,
     );
     fireEvent.click(screen.getByText("Persona 2"));
-    fireEvent.click(screen.getByText("sidePanel.scopeDialog.cancel"));
+    expect(screen.getByText("sidePanel.scopeDialog.title")).toBeTruthy();
+
+    fireEvent.keyDown(document.activeElement ?? document.body, {
+      key: "Escape",
+      code: "Escape",
+    });
+
+    expect(screen.queryByText("sidePanel.scopeDialog.title")).toBeNull();
     expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("puts the bulk action first, as the primary choice", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="a"
+      />,
+    );
+    fireEvent.click(screen.getByText("Persona 2"));
+
+    const buttons = screen.getAllByRole("button");
+    const labels = buttons.map((b) => b.textContent);
+    const allIdx = labels.findIndex((l) => l?.includes("scopeDialog.allTurns"));
+    const oneIdx = labels.findIndex((l) =>
+      l?.includes("scopeDialog.thisTurnOnly"),
+    );
+    expect(allIdx).toBeGreaterThanOrEqual(0);
+    expect(allIdx).toBeLessThan(oneIdx);
+    expect(labels.some((l) => l?.includes("scopeDialog.cancel"))).toBe(false);
   });
 });
 

--- a/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.test.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.test.tsx
@@ -14,7 +14,10 @@ vi.stubGlobal(
 );
 
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts ? `${key}:${JSON.stringify(opts)}` : key,
+  }),
 }));
 
 const dispatch = vi.fn();
@@ -89,7 +92,7 @@ describe("TurnSidePanel timestamp editing", () => {
     fireEvent.change(input, { target: { value: "00:30" } }); // 30s, past "c" at 20s
     expect(dispatch).not.toHaveBeenCalled();
     expect(showToast).toHaveBeenCalledWith(
-      "sidePanel.timestampOutOfRange",
+      expect.stringContaining("sidePanel.timestampOutOfRange"),
       "warning",
     );
   });
@@ -300,7 +303,7 @@ describe("TurnSidePanel bulk-apply scope prompt", () => {
       />,
     );
     fireEvent.click(screen.getByText("Persona 2"));
-    fireEvent.click(screen.getByText("sidePanel.scopeDialog.allTurns"));
+    fireEvent.click(screen.getByText(/sidePanel\.scopeDialog\.allTurns/));
 
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -439,7 +442,7 @@ describe("TurnSidePanel role options menu", () => {
     fireEvent.click(screen.getByRole("button", { name: "Juez/a" }));
 
     expect(screen.getByText("sidePanel.scopeDialog.title")).toBeTruthy();
-    fireEvent.click(screen.getByText("sidePanel.scopeDialog.allTurns"));
+    fireEvent.click(screen.getByText(/sidePanel\.scopeDialog\.allTurns/));
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "RENAME_SPEAKER_GLOBAL",
@@ -463,5 +466,84 @@ describe("TurnSidePanel role options menu", () => {
     // (index 1) is used to disambiguate from the header (index 0).
     fireEvent.click(screen.getAllByText("Persona 1")[1]); // s1 ya es el orador del turno "a"
     expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("TurnSidePanel apply-change toast", () => {
+  beforeEach(() => {
+    dispatch.mockClear();
+    showToast.mockClear();
+  });
+
+  it("reports a single updated turn when there is no scope prompt", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="b" // único turno de s2
+      />,
+    );
+    fireEvent.click(screen.getByText("Persona 1"));
+
+    expect(showToast).toHaveBeenCalledTimes(1);
+    const [message, variant] = showToast.mock.calls[0];
+    expect(variant).toBe("success");
+    expect(message).toContain("sidePanel.changeApplied");
+    expect(message).toContain('"count":1');
+  });
+
+  it("reports the real turn count when applying to all of the speaker's turns", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="a" // s1 tiene los turnos a y c
+      />,
+    );
+    fireEvent.click(screen.getByText("Persona 2"));
+    fireEvent.click(screen.getByText(/sidePanel\.scopeDialog\.allTurns/));
+
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(showToast.mock.calls[0][0]).toContain('"count":2');
+  });
+
+  it("reports one turn when only this turn is changed", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="a"
+      />,
+    );
+    fireEvent.click(screen.getByText("Persona 2"));
+    fireEvent.click(screen.getByText("sidePanel.scopeDialog.thisTurnOnly"));
+
+    expect(showToast).toHaveBeenCalledTimes(1);
+    expect(showToast.mock.calls[0][0]).toContain('"count":1');
+  });
+
+  it("names the speaker being replaced as `from`, and the new one as `to`", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="a" // orador actual: "Persona 1"
+      />,
+    );
+    fireEvent.click(screen.getByText("Persona 2"));
+    fireEvent.click(screen.getByText(/sidePanel\.scopeDialog\.allTurns/));
+
+    const message = showToast.mock.calls[0][0];
+    expect(message).toContain('"from":"Persona 1"');
+    expect(message).toContain('"to":"Persona 2"');
+  });
+
+  it("reports the role name when the change comes from the 'Nuevo' menu", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="b" // único turno de s2, así que no hay diálogo
+      />,
+    );
+    fireEvent.click(screen.getByText("Nuevo"));
+    fireEvent.click(screen.getByRole("button", { name: "Juez/a" }));
+
+    expect(showToast.mock.calls[0][0]).toContain('"to":"Juez/a"');
   });
 });

--- a/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.test.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.test.tsx
@@ -434,7 +434,7 @@ describe("TurnSidePanel role options menu", () => {
     fireEvent.click(screen.getByText("Nuevo"));
 
     expect(screen.getByRole("button", { name: "Juez/a" })).toBeTruthy();
-    // "Fiscal" ya existe como orador: aparece como pill, no como opción.
+    // "Fiscal" already exists as a speaker: it shows up as a pill, not an option.
     expect(screen.queryByRole("button", { name: "Fiscal" })).toBeNull();
   });
 
@@ -442,7 +442,7 @@ describe("TurnSidePanel role options menu", () => {
     render(
       <TurnSidePanel
         transcription={multiSpeakerTranscription}
-        activeTurnId="b" // "b" es el único turno de s2
+        activeTurnId="b" // "b" is s2's only turn
       />,
     );
     fireEvent.click(screen.getByText("Nuevo"));
@@ -469,7 +469,7 @@ describe("TurnSidePanel role options menu", () => {
     render(
       <TurnSidePanel
         transcription={multiSpeakerTranscription}
-        activeTurnId="a" // s1 tiene los turnos a y c
+        activeTurnId="a" // s1 has turns a and c
       />,
     );
     fireEvent.click(screen.getByText("Nuevo"));
@@ -630,7 +630,7 @@ describe("TurnSidePanel apply-change toast", () => {
     render(
       <TurnSidePanel
         transcription={multiSpeakerTranscription}
-        activeTurnId="b" // único turno de s2
+        activeTurnId="b" // s2's only turn
       />,
     );
     fireEvent.click(screen.getByText("Persona 1"));
@@ -646,7 +646,7 @@ describe("TurnSidePanel apply-change toast", () => {
     render(
       <TurnSidePanel
         transcription={multiSpeakerTranscription}
-        activeTurnId="a" // s1 tiene los turnos a y c
+        activeTurnId="a" // s1 has turns a and c
       />,
     );
     fireEvent.click(screen.getByText("Persona 2"));
@@ -674,7 +674,7 @@ describe("TurnSidePanel apply-change toast", () => {
     render(
       <TurnSidePanel
         transcription={multiSpeakerTranscription}
-        activeTurnId="a" // orador actual: "Persona 1"
+        activeTurnId="a" // current speaker: "Persona 1"
       />,
     );
     fireEvent.click(screen.getByText("Persona 2"));
@@ -689,7 +689,7 @@ describe("TurnSidePanel apply-change toast", () => {
     render(
       <TurnSidePanel
         transcription={multiSpeakerTranscription}
-        activeTurnId="b" // único turno de s2, así que no hay diálogo
+        activeTurnId="b" // s2's only turn, so no dialog
       />,
     );
     fireEvent.click(screen.getByText("Nuevo"));

--- a/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.test.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.test.tsx
@@ -373,6 +373,13 @@ describe("TurnSidePanel new-person numbering", () => {
     render(<TurnSidePanel transcription={renamedOnly} activeTurnId="a" />);
     fireEvent.click(screen.getByText("Nuevo"));
     fireEvent.click(screen.getByRole("button", { name: "Nueva persona" }));
+    // "a" is one of this fixture's 3 turns for "s1" (unlike `withCustomAndPersona`
+    // below, which trims turns down to 1), so with the scope-prompt behavior
+    // added in this change, choosing "Nueva persona" now opens the scope
+    // dialog first — same as any other identity change for a multi-turn
+    // speaker. Resolve it via "Sólo este turno" to reach the dispatch this
+    // regression test cares about.
+    fireEvent.click(screen.getByText("sidePanel.scopeDialog.thisTurnOnly"));
 
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -493,6 +500,123 @@ describe("TurnSidePanel role options menu", () => {
     // (index 1) is used to disambiguate from the header (index 0).
     fireEvent.click(screen.getAllByText("Persona 1")[1]); // s1 ya es el orador del turno "a"
     expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("TurnSidePanel 'Nueva persona' from the Nuevo menu", () => {
+  beforeEach(() => {
+    dispatch.mockClear();
+    showToast.mockClear();
+  });
+
+  it("applies immediately with no prompt when the current speaker has only one turn", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="b" // s2's only turn
+      />,
+    );
+    fireEvent.click(screen.getByText("Nuevo"));
+    fireEvent.click(screen.getByRole("button", { name: "Nueva persona" }));
+
+    expect(screen.queryByText("sidePanel.scopeDialog.title")).toBeNull();
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "ADD_SPEAKER",
+        payload: expect.objectContaining({
+          speaker: expect.objectContaining({ label: "Persona 3" }),
+        }),
+      }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "REASSIGN_TURN_SPEAKER",
+        payload: expect.objectContaining({ turnId: "b" }),
+      }),
+    );
+  });
+
+  it("prompts for scope when the current speaker has more than one turn", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="a" // s1's turns: a, c
+      />,
+    );
+    fireEvent.click(screen.getByText("Nuevo"));
+    fireEvent.click(screen.getByRole("button", { name: "Nueva persona" }));
+
+    expect(screen.getByText("sidePanel.scopeDialog.title")).toBeTruthy();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("creates a new speaker and reassigns only this turn on 'Sólo este turno'", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="a"
+      />,
+    );
+    fireEvent.click(screen.getByText("Nuevo"));
+    fireEvent.click(screen.getByRole("button", { name: "Nueva persona" }));
+    fireEvent.click(screen.getByText("sidePanel.scopeDialog.thisTurnOnly"));
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "ADD_SPEAKER",
+        payload: expect.objectContaining({
+          speaker: expect.objectContaining({ label: "Persona 3" }),
+        }),
+      }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "REASSIGN_TURN_SPEAKER",
+        payload: expect.objectContaining({ turnId: "a" }),
+      }),
+    );
+  });
+
+  it("renames the current speaker's every turn on 'Todas las de X'", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="a"
+      />,
+    );
+    fireEvent.click(screen.getByText("Nuevo"));
+    fireEvent.click(screen.getByRole("button", { name: "Nueva persona" }));
+    fireEvent.click(screen.getByText(/sidePanel\.scopeDialog\.allTurns/));
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "RENAME_SPEAKER_GLOBAL",
+        payload: expect.objectContaining({
+          speakerId: "s1",
+          newLabel: "Persona 3",
+        }),
+      }),
+    );
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "ADD_SPEAKER" }),
+    );
+  });
+
+  it("shows a success toast after creating a new person, with the real turn count", () => {
+    render(
+      <TurnSidePanel
+        transcription={multiSpeakerTranscription}
+        activeTurnId="a"
+      />,
+    );
+    fireEvent.click(screen.getByText("Nuevo"));
+    fireEvent.click(screen.getByRole("button", { name: "Nueva persona" }));
+    fireEvent.click(screen.getByText("sidePanel.scopeDialog.thisTurnOnly"));
+
+    expect(showToast).toHaveBeenCalledTimes(1);
+    const message = showToast.mock.calls[0][0];
+    expect(message).toContain('"to":"Persona 3"');
+    expect(message).toContain('"count":1');
   });
 });
 

--- a/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/reducers/transcription/actions";
 import { SUGGESTED_SPEAKERS } from "@/services/aymurai/fixtures/suggestedSpeakers";
 import { css } from "@/styled/css";
+import { stack } from "@/styled/patterns";
 import type {
   Speaker,
   SuggestedSpeaker,
@@ -29,7 +30,6 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogTitle,
   SidePanel,
   TooltipProvider,
@@ -83,19 +83,26 @@ const emptyPanel = css({
   p: "6",
 });
 
-// Lightweight text-link Cancel, matching the "Ya existe" Figma reference
-// (bordered buttons for the real actions, plain text for Cancelar) instead of
-// a third equally-weighted bordered button crowding the footer.
-const cancelLink = css({
-  color: "text.lighter",
-  textStyle: "label.md.default",
-  textDecoration: "underline",
-  cursor: "pointer",
-  bg: "transparent",
-  border: "[none]",
-  p: "[0]",
-  mr: "auto",
-  "&:hover": { color: "brand.primary" },
+// Tratamiento de confirmación del Figma nodo 40002384:38487 — el mismo que
+// usa el ConfirmDialog interno de @aymurai/ui para el conflicto de nombres.
+// Se replica en vez de importarse porque ese componente no es público y trae
+// los labels "Combinar"/"Cancelar" hardcodeados.
+const confirmCard = css({ ...stack.raw({ gap: "4" }), maxW: "[389px]" });
+const confirmTextBlock = css({ ...stack.raw({ gap: "1" }) });
+const confirmTitle = css({
+  margin: "0",
+  textStyle: "subtitle.md.strong",
+  color: "text.default",
+});
+const confirmDescription = css({
+  margin: "0",
+  textStyle: "subtitle.sm.default",
+  color: "text.default",
+});
+const confirmButtons = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "3", // 12px
 });
 
 export interface TurnSidePanelProps {
@@ -382,30 +389,33 @@ export default function TurnSidePanel({
           if (!open) setScopeChoice(null);
         }}
       >
-        <DialogContent size="sm">
-          <DialogTitle>{t("sidePanel.scopeDialog.title")}</DialogTitle>
-          <DialogDescription>
-            {t("sidePanel.scopeDialog.description", {
-              current: currentSpeaker?.label,
-            })}
-          </DialogDescription>
-          <DialogFooter>
-            <button
-              type="button"
-              className={cancelLink}
-              onClick={() => setScopeChoice(null)}
-            >
-              {t("sidePanel.scopeDialog.cancel")}
-            </button>
-            <Button variant="secondary" onClick={handleApplyToThisTurnOnly}>
-              {t("sidePanel.scopeDialog.thisTurnOnly")}
-            </Button>
-            <Button onClick={handleApplyToAllTurns}>
+        <DialogContent className={confirmCard}>
+          <div className={confirmTextBlock}>
+            <DialogTitle asChild>
+              <p className={confirmTitle}>{t("sidePanel.scopeDialog.title")}</p>
+            </DialogTitle>
+            <DialogDescription asChild>
+              <p className={confirmDescription}>
+                {t("sidePanel.scopeDialog.description", {
+                  current: currentSpeaker.label,
+                })}
+              </p>
+            </DialogDescription>
+          </div>
+          <div className={confirmButtons}>
+            <Button variant="primary" size="sm" onClick={handleApplyToAllTurns}>
               {t("sidePanel.scopeDialog.allTurns", {
-                current: currentSpeaker?.label,
+                current: currentSpeaker.label,
               })}
             </Button>
-          </DialogFooter>
+            <Button
+              variant="tertiary"
+              size="sm"
+              onClick={handleApplyToThisTurnOnly}
+            >
+              {t("sidePanel.scopeDialog.thisTurnOnly")}
+            </Button>
+          </div>
         </DialogContent>
       </Dialog>
     </div>

--- a/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.tsx
@@ -83,10 +83,10 @@ const emptyPanel = css({
   p: "6",
 });
 
-// Tratamiento de confirmación del Figma nodo 40002384:38487 — el mismo que
-// usa el ConfirmDialog interno de @aymurai/ui para el conflicto de nombres.
-// Se replica en vez de importarse porque ese componente no es público y trae
-// los labels "Combinar"/"Cancelar" hardcodeados.
+// Confirmation treatment from Figma node 40002384:38487 — the same one
+// @aymurai/ui's internal ConfirmDialog uses for the name-conflict prompt.
+// Replicated instead of imported because that component isn't public and
+// hardcodes the "Combinar"/"Cancelar" labels.
 const confirmCard = css({ ...stack.raw({ gap: "4" }), maxW: "[389px]" });
 const confirmTextBlock = css({ ...stack.raw({ gap: "1" }) });
 const confirmTitle = css({
@@ -155,8 +155,8 @@ export default function TurnSidePanel({
     return <aside className={emptyPanel}>{t("sidePanel.empty")}</aside>;
   }
 
-  // Pills = sólo los oradores detectados. Los roles ya no van acá: viven en el
-  // desplegable de "Nuevo".
+  // Pills = only the detected speakers. Roles no longer go here: they live
+  // in the "Nuevo" dropdown.
   const people = speakers.map((s) => ({
     id: s.id,
     initials: s.initials,
@@ -166,7 +166,7 @@ export default function TurnSidePanel({
   }));
   const selectedIndex = speakers.findIndex((s) => s.id === currentSpeaker.id);
 
-  // Roles todavía no usados, para el desplegable.
+  // Roles not yet used, for the dropdown.
   const usedLabels = new Set(speakers.map((s) => s.label.toLowerCase()));
   const availableSuggested = SUGGESTED_SPEAKERS.filter(
     (sg) => !usedLabels.has(sg.label.toLowerCase()),
@@ -215,10 +215,10 @@ export default function TurnSidePanel({
   ).length;
 
   /**
-   * Toast de confirmación (Figma nodo 40002383:73634). Se llama dentro del
-   * mismo handler que despacha, para que `currentSpeaker.label` siga siendo el
-   * valor de este render: después del dispatch el componente se re-renderiza y
-   * el mensaje diría "de Fiscal a Fiscal".
+   * Confirmation toast (Figma node 40002383:73634). Called inside the same
+   * handler that dispatches, so `currentSpeaker.label` still reads this
+   * render's value: after the dispatch the component re-renders and the
+   * message would say "from Fiscal to Fiscal".
    */
   const notifyApplied = (targetLabel: string, count: number) => {
     showToast(
@@ -231,7 +231,7 @@ export default function TurnSidePanel({
     );
   };
 
-  /** Decide entre aplicar directo o pedir alcance. Común a los dos caminos. */
+  /** Decides between applying directly or asking for scope. Shared by both paths. */
   const requestSelection = (pending: PendingSelection, targetLabel: string) => {
     if (currentSpeakerTurnCount > 1) {
       setScopeChoice({ pending, targetLabel });

--- a/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.tsx
@@ -17,7 +17,12 @@ import {
 } from "@/reducers/transcription/actions";
 import { SUGGESTED_SPEAKERS } from "@/services/aymurai/fixtures/suggestedSpeakers";
 import { css } from "@/styled/css";
-import type { Speaker, Transcription, Turn } from "@/types/transcription";
+import type {
+  Speaker,
+  SuggestedSpeaker,
+  Transcription,
+  Turn,
+} from "@/types/transcription";
 import { SPEAKER_PALETTE } from "@/types/transcription";
 import {
   Button,
@@ -98,6 +103,10 @@ export interface TurnSidePanelProps {
   activeTurnId: string | null;
 }
 
+type PendingSelection =
+  | { kind: "existing"; speakerId: string }
+  | { kind: "role"; role: SuggestedSpeaker };
+
 /**
  * Edit-mode side panel. Thin adapter that wires the transcription reducer to
  * the @aymurai/ui SidePanel component (Figma-aligned). The library component
@@ -125,7 +134,7 @@ export default function TurnSidePanel({
   // the handlers that use it, so every render calls the same hooks in the
   // same order regardless of whether activeTurn/currentSpeaker are set.
   const [scopeChoice, setScopeChoice] = useState<{
-    personIndex: number;
+    pending: PendingSelection;
     targetLabel: string;
   } | null>(null);
 
@@ -138,46 +147,41 @@ export default function TurnSidePanel({
     return <aside className={emptyPanel}>{t("sidePanel.empty")}</aside>;
   }
 
-  // People pills = existing speakers first, then still-unused suggested roles.
+  // Pills = sólo los oradores detectados. Los roles ya no van acá: viven en el
+  // desplegable de "Nuevo".
+  const people = speakers.map((s) => ({
+    id: s.id,
+    initials: s.initials,
+    name: s.label,
+    color: s.color,
+    renamable: true,
+  }));
+  const selectedIndex = speakers.findIndex((s) => s.id === currentSpeaker.id);
+
+  // Roles todavía no usados, para el desplegable.
   const usedLabels = new Set(speakers.map((s) => s.label.toLowerCase()));
   const availableSuggested = SUGGESTED_SPEAKERS.filter(
     (sg) => !usedLabels.has(sg.label.toLowerCase()),
   );
-  const people = [
-    ...speakers.map((s) => ({
-      kind: "existing" as const,
-      id: s.id,
-      initials: s.initials,
-      name: s.label,
-      color: s.color,
-      renamable: true,
-    })),
-    ...availableSuggested.map((sg) => ({
-      kind: "suggested" as const,
-      id: sg.id,
-      sg,
-      initials: sg.initials,
-      name: sg.label,
-      color: sg.color,
-      renamable: false,
-    })),
-  ];
-  const selectedIndex = people.findIndex(
-    (p) => p.kind === "existing" && p.id === currentSpeaker.id,
-  );
+  const newPersonOptions = availableSuggested.map((sg) => ({
+    id: sg.id,
+    initials: sg.initials,
+    name: sg.label,
+    color: sg.color,
+  }));
 
-  const applySelection = (i: number) => {
-    const p = people[i];
-    if (!p) return;
-    if (p.kind === "existing") {
-      dispatch(reassignTurnSpeaker(transcription.id, activeTurn.id, p.id));
+  const applySelection = (pending: PendingSelection) => {
+    if (pending.kind === "existing") {
+      dispatch(
+        reassignTurnSpeaker(transcription.id, activeTurn.id, pending.speakerId),
+      );
       return;
     }
     const newSpeaker: Speaker = {
       id: crypto.randomUUID(),
-      label: p.sg.label,
-      initials: p.sg.initials,
-      color: p.sg.color,
+      label: pending.role.label,
+      initials: pending.role.initials,
+      color: pending.role.color,
     };
     dispatch(addSpeaker(transcription.id, newSpeaker));
     dispatch(
@@ -185,32 +189,44 @@ export default function TurnSidePanel({
     );
   };
 
-  const handleSelectPerson = (i: number) => {
-    const p = people[i];
-    if (!p || !currentSpeaker) return;
+  const currentSpeakerTurnCount = turns.filter(
+    (t) => t.speakerId === currentSpeaker.id,
+  ).length;
 
-    const targetLabel = p.kind === "existing" ? p.name : p.sg.label;
-    const isDifferentIdentity =
-      p.kind === "suggested" || p.id !== currentSpeaker.id;
-    const currentSpeakerTurnCount = turns.filter(
-      (t) => t.speakerId === currentSpeaker.id,
-    ).length;
-
-    if (isDifferentIdentity && currentSpeakerTurnCount > 1) {
-      setScopeChoice({ personIndex: i, targetLabel });
+  /** Decide entre aplicar directo o pedir alcance. Común a los dos caminos. */
+  const requestSelection = (pending: PendingSelection, targetLabel: string) => {
+    if (currentSpeakerTurnCount > 1) {
+      setScopeChoice({ pending, targetLabel });
       return;
     }
-    applySelection(i);
+    applySelection(pending);
+  };
+
+  /** Click en una pill de la grilla (un orador existente). */
+  const handleSelectPerson = (index: number) => {
+    const speaker = speakers[index];
+    if (!speaker || speaker.id === currentSpeaker.id) return;
+    requestSelection(
+      { kind: "existing", speakerId: speaker.id },
+      speaker.label,
+    );
+  };
+
+  /** Click en un rol del desplegable de "Nuevo". */
+  const handleSelectNewPersonOption = (index: number) => {
+    const role = availableSuggested[index];
+    if (!role) return;
+    requestSelection({ kind: "role", role }, role.label);
   };
 
   const handleApplyToThisTurnOnly = () => {
     if (!scopeChoice) return;
-    applySelection(scopeChoice.personIndex);
+    applySelection(scopeChoice.pending);
     setScopeChoice(null);
   };
 
   const handleApplyToAllTurns = () => {
-    if (!scopeChoice || !currentSpeaker) return;
+    if (!scopeChoice) return;
     dispatch(
       renameSpeakerGlobal(
         transcription.id,
@@ -269,16 +285,16 @@ export default function TurnSidePanel({
     : undefined;
 
   const handleRenamePerson = (personIndex: number, name: string) => {
-    const person = people[personIndex];
-    if (person?.kind !== "existing") return;
-    dispatch(renameSpeakerGlobal(transcription.id, person.id, name));
+    const speaker = speakers[personIndex];
+    if (!speaker) return;
+    dispatch(renameSpeakerGlobal(transcription.id, speaker.id, name));
   };
 
   const handleMergePeople = (sourceIndex: number, targetIndex: number) => {
-    const source = people[sourceIndex];
-    const target = people[targetIndex];
-    if (source?.kind !== "existing" || target?.kind !== "existing") return;
-    dispatch(renameSpeakerGlobal(transcription.id, source.id, target.name));
+    const source = speakers[sourceIndex];
+    const target = speakers[targetIndex];
+    if (!source || !target) return;
+    dispatch(renameSpeakerGlobal(transcription.id, source.id, target.label));
   };
 
   const handleAddBelow = () => {
@@ -317,15 +333,11 @@ export default function TurnSidePanel({
             time: formatTime(activeTurn.startMs),
             color: currentSpeaker.color,
           }}
-          people={people.map((p) => ({
-            id: p.id,
-            initials: p.initials,
-            name: p.name,
-            color: p.color,
-            renamable: p.renamable,
-          }))}
+          people={people}
           selectedIndex={selectedIndex >= 0 ? selectedIndex : undefined}
           onSelectPerson={handleSelectPerson}
+          newPersonOptions={newPersonOptions}
+          onSelectNewPersonOption={handleSelectNewPersonOption}
           onNewPerson={handleNewPerson}
           onRenamePerson={handleRenamePerson}
           onMergePeople={handleMergePeople}

--- a/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.tsx
@@ -193,6 +193,23 @@ export default function TurnSidePanel({
     (t) => t.speakerId === currentSpeaker.id,
   ).length;
 
+  /**
+   * Toast de confirmación (Figma nodo 40002383:73634). Se llama dentro del
+   * mismo handler que despacha, para que `currentSpeaker.label` siga siendo el
+   * valor de este render: después del dispatch el componente se re-renderiza y
+   * el mensaje diría "de Fiscal a Fiscal".
+   */
+  const notifyApplied = (targetLabel: string, count: number) => {
+    showToast(
+      t("sidePanel.changeApplied", {
+        from: currentSpeaker.label,
+        to: targetLabel,
+        count,
+      }),
+      "success",
+    );
+  };
+
   /** Decide entre aplicar directo o pedir alcance. Común a los dos caminos. */
   const requestSelection = (pending: PendingSelection, targetLabel: string) => {
     if (currentSpeakerTurnCount > 1) {
@@ -200,6 +217,7 @@ export default function TurnSidePanel({
       return;
     }
     applySelection(pending);
+    notifyApplied(targetLabel, 1);
   };
 
   /** Click en una pill de la grilla (un orador existente). */
@@ -222,6 +240,7 @@ export default function TurnSidePanel({
   const handleApplyToThisTurnOnly = () => {
     if (!scopeChoice) return;
     applySelection(scopeChoice.pending);
+    notifyApplied(scopeChoice.targetLabel, 1);
     setScopeChoice(null);
   };
 
@@ -234,6 +253,7 @@ export default function TurnSidePanel({
         scopeChoice.targetLabel,
       ),
     );
+    notifyApplied(scopeChoice.targetLabel, currentSpeakerTurnCount);
     setScopeChoice(null);
   };
 

--- a/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.tsx
+++ b/src/renderer/src/components/voice-to-text/transcription-editor/turn-side-panel.tsx
@@ -112,7 +112,8 @@ export interface TurnSidePanelProps {
 
 type PendingSelection =
   | { kind: "existing"; speakerId: string }
-  | { kind: "role"; role: SuggestedSpeaker };
+  | { kind: "role"; role: SuggestedSpeaker }
+  | { kind: "new" };
 
 /**
  * Edit-mode side panel. Thin adapter that wires the transcription reducer to
@@ -177,6 +178,16 @@ export default function TurnSidePanel({
     color: sg.color,
   }));
 
+  const buildNewPersonSpeaker = (): Speaker => {
+    const label = nextPersonaLabel(speakers);
+    return {
+      id: crypto.randomUUID(),
+      label,
+      initials: computeInitials(label),
+      color: SPEAKER_PALETTE[speakers.length % SPEAKER_PALETTE.length],
+    };
+  };
+
   const applySelection = (pending: PendingSelection) => {
     if (pending.kind === "existing") {
       dispatch(
@@ -184,12 +195,15 @@ export default function TurnSidePanel({
       );
       return;
     }
-    const newSpeaker: Speaker = {
-      id: crypto.randomUUID(),
-      label: pending.role.label,
-      initials: pending.role.initials,
-      color: pending.role.color,
-    };
+    const newSpeaker: Speaker =
+      pending.kind === "role"
+        ? {
+            id: crypto.randomUUID(),
+            label: pending.role.label,
+            initials: pending.role.initials,
+            color: pending.role.color,
+          }
+        : buildNewPersonSpeaker();
     dispatch(addSpeaker(transcription.id, newSpeaker));
     dispatch(
       reassignTurnSpeaker(transcription.id, activeTurn.id, newSpeaker.id),
@@ -265,17 +279,7 @@ export default function TurnSidePanel({
   };
 
   const handleNewPerson = () => {
-    const label = nextPersonaLabel(speakers);
-    const newSpeaker: Speaker = {
-      id: crypto.randomUUID(),
-      label,
-      initials: computeInitials(label),
-      color: SPEAKER_PALETTE[speakers.length % SPEAKER_PALETTE.length],
-    };
-    dispatch(addSpeaker(transcription.id, newSpeaker));
-    dispatch(
-      reassignTurnSpeaker(transcription.id, activeTurn.id, newSpeaker.id),
-    );
+    requestSelection({ kind: "new" }, nextPersonaLabel(speakers));
   };
 
   const { minMs, maxMs } = getTimestampBounds(

--- a/src/renderer/src/constants/i18n/locales/es/voice-to-text.ts
+++ b/src/renderer/src/constants/i18n/locales/es/voice-to-text.ts
@@ -130,6 +130,7 @@ const voiceToText = {
   speakerPicker: {
     people: "Personas",
     suggested: "Roles sugeridos",
+    new: "Nuevo",
     newPerson: "Nueva persona",
     newPersonPlaceholder: "Nombre de la persona",
     create: "Crear",

--- a/src/renderer/src/constants/i18n/locales/es/voice-to-text.ts
+++ b/src/renderer/src/constants/i18n/locales/es/voice-to-text.ts
@@ -140,6 +140,10 @@ const voiceToText = {
   sidePanel: {
     empty: "Seleccioná un turno para editar sus propiedades.",
     selectedTurn: "Turno seleccionado",
+    changeApplied_one:
+      "Se aplicó con éxito el cambio de {{from}} a {{to}} · 1 turno actualizado",
+    changeApplied_other:
+      "Se aplicó con éxito el cambio de {{from}} a {{to}} · {{count}} turnos actualizados",
     startsAt: "Inicia en {{time}}",
     renameAria: "Renombrar locutor en todos los turnos",
     renamePlaceholder: "Nombre del locutor",

--- a/src/renderer/src/constants/i18n/locales/es/voice-to-text.ts
+++ b/src/renderer/src/constants/i18n/locales/es/voice-to-text.ts
@@ -166,7 +166,6 @@ const voiceToText = {
         '"{{current}}" tiene más de una intervención en esta transcripción. ¿Aplicás el cambio sólo a este turno o a todas las intervenciones de "{{current}}"?',
       thisTurnOnly: "Sólo este turno",
       allTurns: "Todas las de {{current}}",
-      cancel: "Cancelar",
     },
   },
 };


### PR DESCRIPTION
## Summary

Redesigns the Voz a Texto (speech-to-text) turn editor's side panel so the "Personas identificadas" section lists only the speakers actually detected in the audio. The eight suggested judicial roles (Juez/a, Fiscal, Defensor/a, ...) move behind a new "Nuevo" dropdown, backed by the `PersonMenu` component from `@aymurai/ui@0.6.0`.

- Bump `@aymurai/ui` to the released `v0.6.0` tag (adds `PersonMenu` and the `SidePanel.newPersonOptions`/`onSelectNewPersonOption` props).
- Split `turn-side-panel.tsx`'s combined speakers+roles list into two, replacing a `kind: "existing" | "suggested"` discriminant with a `PendingSelection` union (`existing` | `role` | `new`) threaded through the scope-prompt dialog and a new success toast.
- Restyle the "Aplicar cambio" confirmation dialog to match the app's other confirmation treatment (2 buttons instead of 3; Escape/click-outside dismisses it).
- Rebuild `speaker-picker.tsx` (the floating selection toolbar's "Asignar a…" popover) on the same shared `PersonMenu`, as a two-step flow inside one popover — unifies its visuals with the side panel and keeps `splitTurn` intact.
- Tokenize two previously-raw-hex Panda CSS values in that floating toolbar's dark surface.
- Unify "Nueva persona" (in the new "Nuevo" menu) with the sibling role-picking action: it now goes through the same scope prompt and success toast, instead of always applying silently.

## Test plan

- [x] `pnpm typecheck`, `pnpm test` (350/350, 66 files), `pnpm knip` all clean
- [x] Full whole-branch code review, with one fix-and-reverify round for two findings that surfaced only at that level
- [ ] Manual QA with a display (no sandbox in this session had one):
  - [ ] "Aplicar cambio" dialog visually matches Figma node `40002384:38487`
  - [ ] `PersonMenu`'s card visuals (background/shadow/scroll) render correctly inside the floating selection toolbar with many speakers
  - [ ] End-to-end: select text → "Asignar a…" → "Nuevo" → pick a role / "Nueva persona" → confirm the fragment is split and assigned via `splitTurn`
  - [ ] The floating toolbar's dark surface still renders correctly after the token change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Redesign the Voz a Texto turn side panel and floating speaker picker to separate identified speakers from suggested roles, unify their interactions on a shared person menu, and provide clearer scoped-apply flows with success feedback toasts.

Enhancements:
- Show only actually detected speakers as pills in the turn side panel while moving suggested judicial roles into a dedicated "Nuevo" menu backed by the shared PersonMenu component.
- Unify identity-change flows (existing speaker, suggested role, and "Nueva persona") so that multi-turn speakers trigger a scope dialog and all successful changes emit a contextual success toast with turn counts and from/to labels.
- Restyle the scope confirmation dialog to match the app-wide confirmation pattern and make it dismissible via Escape or outside click, with the primary bulk action presented first.
- Refactor the floating selection toolbar’s speaker picker to use PersonMenu in a two-step people/roles flow, aligning visuals and behavior with the side panel.
- Tokenize the floating toolbar’s dark surface background and text colors into Panda CSS semantic tokens and adjust radii/shadows to use design tokens instead of raw values.

Build:
- Bump @aymurai/ui dependency to v0.6.0 and update the pnpm workspace allowBuilds entry to the corresponding tagged commit.

Tests:
- Extend TurnSidePanel tests to cover the new scoped-apply behavior, dialog ordering and dismissal, new-person flows, and success toast messaging.
- Add a dedicated SpeakerPicker test suite to validate the two-step people/roles flow, creation of suggested and free-text speakers, and integration with the transcription reducer.