### PR TITLE
Use a middle dot instead of a hyphen in the audio file preview meta line

### DIFF
--- a/src/renderer/src/constants/i18n/locales/es/voice-to-text.ts
+++ b/src/renderer/src/constants/i18n/locales/es/voice-to-text.ts
@@ -60,7 +60,7 @@ const voiceToText = {
     removeAria: "Eliminar {{name}}",
     playAria: "Reproducir 10 segundos de {{name}}",
     pauseAria: "Pausar {{name}}",
-    meta: "{{duration}} - {{size}}",
+    meta: "{{duration}} · {{size}}",
   },
   process: {
     sectionTitle: "2. Transcripción de voz a texto",


### PR DESCRIPTION
## Summary

- The audio file's `ArchiveRow` description in the Voz a Texto file-selection step ("1. Selección de archivo") read `"5 min. 0 seg. - 18.3 mb"`, using a hyphen where the rest of the app already uses a middle dot.
- `filePreview.meta_one`/`_other` (`common.ts`, used for document previews) already reads `"{{count}} párrafo · {{size}}"` — this was the only remaining `"{{a}} - {{b}}"` pattern in the i18n locales.
- Swaps the separator in `voice-to-text.ts`'s `preview.meta` key to match: `"{{duration}} · {{size}}"`.
- No change in `@aymurai/ui`: `ArchiveRow` only renders the `description` string it's given; the formatting lives entirely in this repo.

## Test plan

- [x] `pnpm typecheck`, `pnpm test` (330/330, 65 files) clean
- [x] Searched all Spanish locale files for other `"{{a}} - {{b}}"` duration/size/count patterns feeding `ArchiveRow` — none found besides the one fixed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Standardize the audio file preview meta format to use a middle dot between duration and size in the Spanish voice-to-text locale.