### PR TITLE
Use page_count from document-extract instead of paragraph count

### DIFF
--- a/src/renderer/src/components/file-preview/index.tsx
+++ b/src/renderer/src/components/file-preview/index.tsx
@@ -83,7 +83,7 @@ export default function FilePreview({ file, status, onRemove }: Props) {
     );
   }
 
-  const paragraphCount = file.paragraphs.length;
+  const pageCount = file.pageCount ?? file.paragraphs.length;
 
   return (
     <div className={layout}>
@@ -100,7 +100,7 @@ export default function FilePreview({ file, status, onRemove }: Props) {
         icon={<FileIcon size={24} />}
         title={file.data.name}
         description={t("filePreview.meta", {
-          count: paragraphCount,
+          count: pageCount,
           size: formatFileSize(file.data.size),
         })}
         trailingAction={

--- a/src/renderer/src/constants/i18n/locales/es/common.ts
+++ b/src/renderer/src/constants/i18n/locales/es/common.ts
@@ -37,8 +37,8 @@ const common = {
   },
   filePreview: {
     loadError: "No se pudo cargar el archivo",
-    meta_one: "{{count}} párrafo · {{size}}",
-    meta_other: "{{count}} párrafos · {{size}}",
+    meta_one: "{{count}} página · {{size}}",
+    meta_other: "{{count}} páginas · {{size}}",
     removeAria: "Eliminar {{name}}",
   },
 };

--- a/src/renderer/src/hooks/useFileParse.ts
+++ b/src/renderer/src/hooks/useFileParse.ts
@@ -37,6 +37,7 @@ export function useFileParse(
             id: `${query.data.document_id}:${paragraphIndex}`,
           })),
           file.data.name,
+          query.data.page_count,
         ),
       );
     });

--- a/src/renderer/src/reducers/file/actions.ts
+++ b/src/renderer/src/reducers/file/actions.ts
@@ -203,20 +203,23 @@ export type AddParagraphsAction = Action<
   {
     paragraphs: Paragraph[];
     fileName: string;
+    pageCount?: number | null;
   }
 >;
 /**
  * Adds paragraphs to the state from the endpoint `/document-extract`
  * @param paragraphs List of paragraphs to be added
  * @param fileName Name of the file to be modified
+ * @param pageCount Page count reported by the endpoint, if any
  */
 export function addParagraphs(
   paragraphs: Paragraph[],
   fileName: string,
+  pageCount?: number | null,
 ): AddParagraphsAction {
   return {
     type: ActionTypes.ADD_PARAGRAPHS,
-    payload: { paragraphs, fileName },
+    payload: { paragraphs, fileName, pageCount },
   };
 }
 

--- a/src/renderer/src/reducers/file/index.ts
+++ b/src/renderer/src/reducers/file/index.ts
@@ -169,11 +169,12 @@ export default function reducer(state: State, action: Action): State {
     // ADD PARAGRAPHS
     // ----------------
     case ActionTypes.ADD_PARAGRAPHS: {
-      const { fileName, paragraphs } = payload;
+      const { fileName, paragraphs, pageCount } = payload;
 
       return update(fileName, (cur) => ({
         ...cur,
         paragraphs: paragraphs,
+        pageCount: pageCount,
       }));
     }
 

--- a/src/renderer/src/schema/extract.ts
+++ b/src/renderer/src/schema/extract.ts
@@ -5,6 +5,7 @@ export const documentExtractSchema = z.object({
   footer: z.string().nullable(),
   header: z.string().nullable(),
   document: z.array(z.string()),
+  page_count: z.number().nullable().optional(),
 
   // Preserving schema for future use
   // id: z.string().uuid(),

--- a/src/renderer/src/types/file.ts
+++ b/src/renderer/src/types/file.ts
@@ -25,6 +25,10 @@ export type DocFile = {
    */
   paragraphs?: Paragraph[];
   /**
+   * Page count reported by the `/misc/document-extract` endpoint
+   */
+  pageCount?: number | null;
+  /**
    * Used on the 'preview' page to detect which files have to be processed
    */
   selected: boolean;


### PR DESCRIPTION
## Summary
- The `/misc/document-extract` endpoint now returns `page_count` (aymurai PR #34), so the file preview meta line ("N párrafos · size") now shows page count instead of the paragraph array length.
- Falls back to paragraph count if `page_count` is absent/null, so behavior is unchanged against older backend versions.

## Changes
- `schema/extract.ts`: added `page_count` to the zod schema.
- `types/file.ts`: added `pageCount` to `DocFile`.
- `reducers/file/actions.ts` + `reducers/file/index.ts`: `addParagraphs`/`ADD_PARAGRAPHS` now also carry/store `pageCount`.
- `hooks/useFileParse.ts`: passes `page_count` through on dispatch.
- `components/file-preview/index.tsx`: preview label uses `pageCount` with paragraph-count fallback.
- `es/common.ts`: `filePreview.meta` strings changed from "párrafo(s)" to "página(s)".

## Test plan
- [x] `pnpm typecheck` passes
- [ ] Manual check: load a document in the app and confirm the preview shows page count

## Summary by Sourcery

Switch file preview metadata to display document page count from the document-extract endpoint, with a fallback to paragraph count for older backends.

New Features:
- Expose pageCount on DocFile and propagate it from the /misc/document-extract response through parsing hooks and file reducer into the UI.

Enhancements:
- Update the Spanish file preview meta text to refer to pages instead of paragraphs.